### PR TITLE
Add CPU variant support with decimal mode fixes

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -80,6 +80,66 @@ func (a AddrModeType) String() string {
 	return "UNKNOWN"
 }
 
+// CPUVariant represents different 6502 processor variants
+type CPUVariant int
+
+const (
+	// VariantNMOS6502 is the original NMOS 6502 (1975)
+	// Used in: Apple II, Commodore 64, Atari 2600/800, BBC Micro
+	// Features: All documented bugs, decimal mode supported
+	VariantNMOS6502 CPUVariant = iota
+
+	// VariantCMOS65C02 is the CMOS 65C02 (1982)
+	// Used in: Apple IIc, Apple IIe (enhanced), later systems
+	// Features: Bug fixes, additional instructions, lower power
+	VariantCMOS65C02
+
+	// VariantRicoh2A03 is the NES/Famicom CPU (1983)
+	// Used in: Nintendo Entertainment System, Famicom
+	// Features: No decimal mode, integrated APU, different timing
+	VariantRicoh2A03
+
+	// VariantRicoh2A07 is the PAL NES CPU
+	// Same as 2A03 but with PAL timing
+	VariantRicoh2A07
+)
+
+// String returns the variant name
+func (v CPUVariant) String() string {
+	names := []string{
+		"NMOS 6502",
+		"CMOS 65C02",
+		"Ricoh 2A03 (NTSC)",
+		"Ricoh 2A07 (PAL)",
+	}
+	if int(v) < len(names) {
+		return names[v]
+	}
+	return "Unknown"
+}
+
+// SupportsDecimalMode returns true if the variant supports decimal mode
+func (v CPUVariant) SupportsDecimalMode() bool {
+	switch v {
+	case VariantRicoh2A03, VariantRicoh2A07:
+		return false
+	default:
+		return true
+	}
+}
+
+// HasIndirectJMPBug returns true if the variant has the indirect JMP page boundary bug
+func (v CPUVariant) HasIndirectJMPBug() bool {
+	switch v {
+	case VariantNMOS6502, VariantRicoh2A03, VariantRicoh2A07:
+		return true
+	case VariantCMOS65C02:
+		return false
+	default:
+		return true
+	}
+}
+
 // Bus interface (remains the same)
 type Bus interface {
 	Read(addr uint16) uint8
@@ -100,7 +160,7 @@ const (
 	N Flags = 1 << 7 // Negative
 )
 
-// CPU struct (remains the same)
+// CPU struct
 type CPU struct {
 	// Registers
 	A  uint8  // Accumulator
@@ -130,6 +190,9 @@ type CPU struct {
 	// Error handling
 	errorHandler ErrorHandler
 	lastError    *CPUError
+
+	// Variant configuration
+	variant CPUVariant
 }
 
 // Instruction struct: Use method expressions for types
@@ -143,28 +206,45 @@ type Instruction struct {
 	Illegal      bool             // Whether this is an official or unofficial/illegal opcode
 }
 
-// NewCPU creates a new CPU with a default logging error handler
+// NewCPU creates a new CPU with default NMOS 6502 variant and logging error handler
 func NewCPU(bus Bus) *CPU {
+	return NewCPUWithVariant(bus, VariantNMOS6502)
+}
+
+// NewCPUWithVariant creates a new CPU with specified variant and default logging error handler
+func NewCPUWithVariant(bus Bus, variant CPUVariant) *CPU {
 	c := &CPU{
 		bus:          bus,
 		P:            U | I,
 		SP:           0xFD,
+		variant:      variant,
 		errorHandler: &LoggingErrorHandler{Logger: log.Default()},
 	}
 	c.buildLookupTable()
 	return c
 }
 
-// NewCPUWithErrorHandler creates a new CPU with a custom error handler
+// NewCPUWithErrorHandler creates a new CPU with default NMOS 6502 variant and custom error handler
 func NewCPUWithErrorHandler(bus Bus, handler ErrorHandler) *CPU {
+	return NewCPUWithVariantAndErrorHandler(bus, VariantNMOS6502, handler)
+}
+
+// NewCPUWithVariantAndErrorHandler creates a new CPU with specified variant and error handler
+func NewCPUWithVariantAndErrorHandler(bus Bus, variant CPUVariant, handler ErrorHandler) *CPU {
 	c := &CPU{
 		bus:          bus,
 		P:            U | I,
 		SP:           0xFD,
+		variant:      variant,
 		errorHandler: handler,
 	}
 	c.buildLookupTable()
 	return c
+}
+
+// Variant returns the CPU variant
+func (c *CPU) Variant() CPUVariant {
+	return c.variant
 }
 
 // Bus Interaction (remains the same)
@@ -302,14 +382,11 @@ func (c *CPU) IND() uint8 {
 	c.PC++
 	ptr := (ptrHi << 8) | ptrLo
 
-	// Simulate the 6502 page boundary bug for indirect JMP:
-	// If the low byte of the pointer is $FF, the high byte is fetched
-	// from $xx00 instead of $xxFF + 1.
-	if ptrLo == 0x00FF {
-		// Read low byte from ptr, high byte from (ptr & 0xFF00)
+	if c.variant.HasIndirectJMPBug() && ptrLo == 0x00FF {
+		// NMOS bug: If low byte is $FF, high byte is fetched from $xx00
 		c.addrAbs = uint16(c.read(ptr)) | (uint16(c.read(ptr&0xFF00)) << 8)
 	} else {
-		// Normal case: read from ptr and ptr+1
+		// CMOS fix: Normal behavior
 		c.addrAbs = (uint16(c.read(ptr+1)) << 8) | uint16(c.read(ptr))
 	}
 	return 0
@@ -374,74 +451,62 @@ func (c *CPU) ADC() uint8 {
 		carry = 1
 	}
 
-	var temp uint16
-	var result uint8
-
-	if c.getFlag(D) {
-		// --- Decimal Mode ---
-		// N, V flags are officially undefined/unreliable in decimal mode.
-		// Common emulation practice is to set them based on the intermediate *binary* addition result.
-		// Z flag is set based on the final BCD result.
-		// C flag is set based on whether the BCD result exceeds 99.
-
-		// Calculate intermediate binary sum for N/V flags
-		binarySum := uint16(c.A) + uint16(c.fetchedData) + carry
-		// Set N based on bit 7 of binary sum
-		c.setFlag(N, (binarySum&0x80) > 0)
-		// Set V based on signed overflow of binary sum
-		// Overflow = sign(A) == sign(M) && sign(A) != sign(Result)
-		// Simplified: (~(A^M)) & (A^Result) & 0x80
-		c.setFlag(V, ((^(uint16(c.A) ^ uint16(c.fetchedData)))&(uint16(c.A)^binarySum)&0x0080) > 0)
-
-		// Perform BCD addition
-		low := (c.A & 0x0F) + (c.fetchedData & 0x0F) + uint8(carry)
-		if low > 9 {
-			low += 6 // BCD adjustment for lower nibble
-		}
-		// Calculate high nibble sum including carry from low nibble BCD adjustment
-		high := (c.A >> 4) + (c.fetchedData >> 4)
-		if low > 0x0F { // Check if carry generated from lower nibble (original sum > 9 or adjusted sum >= 16)
-			high++
-		}
-
-		if high > 9 {
-			high += 6 // BCD adjustment for upper nibble
-		}
-
-		// Set C flag if the BCD result (represented by high nibble) exceeded 9 ($99)
-		c.setFlag(C, high > 0x0F)
-
-		// Combine nibbles for the final BCD result
-		result = (high << 4) | (low & 0x0F)
-		c.A = result
-
-		// Set Z flag based on the final BCD result in A
-		c.setFlag(Z, c.A == 0)
-
-	} else {
-		// --- Binary Mode ---
-		temp = uint16(c.A) + uint16(c.fetchedData) + carry
-
-		// Set C flag (unsigned overflow)
-		c.setFlag(C, temp > 0xFF)
-
-		result = uint8(temp & 0x00FF)
-
-		// Set V flag (signed overflow)
-		// Check if signs of operands are the same but sign of result is different
-		// V = (~(A ^ M)) & (A ^ R) & 0x80 != 0
-		c.setFlag(V, ((^(uint16(c.A) ^ uint16(c.fetchedData)))&(uint16(c.A)^temp)&0x0080) > 0)
-
-		// Update Accumulator
-		c.A = result
-
-		// Set Z and N flags based on the result
-		c.setZNFlags(c.A)
+	// Check if decimal mode is supported and enabled
+	if c.getFlag(D) && c.variant.SupportsDecimalMode() {
+		return c.adcDecimal(carry)
 	}
 
-	// ADC potentially requires an extra cycle on page boundary crossing for certain indexed modes
-	// The addressing mode function already returned 1 if a page cross occurred.
-	return 1 // Return 1 indicating the operation itself takes at least 1 cycle, potentially more with page cross
+	// Binary mode (or decimal mode disabled)
+	return c.adcBinary(carry)
+}
+
+func (c *CPU) adcBinary(carry uint16) uint8 {
+	temp := uint16(c.A) + uint16(c.fetchedData) + carry
+	c.setFlag(C, temp > 0xFF)
+	result := uint8(temp & 0x00FF)
+	c.setFlag(V, ((^(uint16(c.A) ^ uint16(c.fetchedData)))&(uint16(c.A)^temp)&0x0080) > 0)
+	c.A = result
+	c.setZNFlags(c.A)
+	return 1
+}
+
+func (c *CPU) adcDecimal(carry uint16) uint8 {
+	// Calculate binary result for N/V flags
+	binarySum := uint16(c.A) + uint16(c.fetchedData) + carry
+
+	// Variant-specific N/V flag handling
+	switch c.variant {
+	case VariantNMOS6502:
+		// NMOS: N/V based on binary intermediate result
+		c.setFlag(N, (binarySum&0x80) > 0)
+		c.setFlag(V, ((^(uint16(c.A) ^ uint16(c.fetchedData)))&(uint16(c.A)^binarySum)&0x0080) > 0)
+	case VariantCMOS65C02:
+		// CMOS: N/V based on binary intermediate result (same as NMOS)
+		c.setFlag(N, (binarySum&0x80) > 0)
+		c.setFlag(V, ((^(uint16(c.A) ^ uint16(c.fetchedData)))&(uint16(c.A)^binarySum)&0x0080) > 0)
+	}
+
+	// BCD arithmetic (corrected algorithm)
+	low := (c.A & 0x0F) + (c.fetchedData & 0x0F) + uint8(carry)
+	lowCarry := uint8(0)
+	if low > 9 {
+		low += 6
+		lowCarry = 1
+	}
+
+	high := (c.A >> 4) + (c.fetchedData >> 4) + lowCarry
+	if high > 9 {
+		high += 6
+		c.setFlag(C, true)
+	} else {
+		c.setFlag(C, false)
+	}
+
+	result := ((high & 0x0F) << 4) | (low & 0x0F)
+	c.A = result
+	c.setFlag(Z, c.A == 0)
+
+	return 1
 }
 
 func (c *CPU) AND() uint8 {
@@ -755,80 +820,75 @@ func (c *CPU) RTS() uint8 {
 // SBC - Subtract with Carry (Borrow)
 func (c *CPU) SBC() uint8 {
 	c.fetchDataIfNeeded()
-	// SBC is effectively A - M - (1 - C)
-	// which is equivalent to ADC with A + (~M) + C
-	value := uint16(c.fetchedData) ^ 0x00FF // ~M (one's complement)
-	var carry uint16 = 0                    // Carry In for the A + (~M) + C operation
+
+	// Check if decimal mode is supported and enabled
+	if c.getFlag(D) && c.variant.SupportsDecimalMode() {
+		return c.sbcDecimal()
+	}
+
+	// Binary mode (or decimal mode disabled)
+	return c.sbcBinary()
+}
+
+func (c *CPU) sbcBinary() uint8 {
+	value := uint16(c.fetchedData) ^ 0x00FF
+	var carry uint16 = 0
 	if c.getFlag(C) {
 		carry = 1
 	}
 
-	var temp uint16
-	var result uint8
+	temp := uint16(c.A) + value + carry
+	c.setFlag(C, temp > 0xFF)
+	result := uint8(temp & 0x00FF)
+	c.setFlag(V, ((^(uint16(c.A) ^ value))&(uint16(c.A)^temp)&0x0080) > 0)
+	c.A = result
+	c.setZNFlags(c.A)
 
-	if c.getFlag(D) {
-		// --- Decimal Mode ---
-		// Similar to ADC, N/V flags based on intermediate binary result, C/Z on final BCD result.
+	return 1
+}
 
-		// Calculate intermediate binary result A + (~M) + C for N/V flags
-		binarySum := uint16(c.A) + value + carry
-		// Set N based on bit 7 of binary sum
-		c.setFlag(N, (binarySum&0x80) > 0)
-		// Set V based on signed overflow of binary sum (A + ~M + C)
-		// Overflow = sign(A) == sign(~M) && sign(A) != sign(Result)
-		// Simplified: (~(A ^ ~M)) & (A ^ Result) & 0x80
-		c.setFlag(V, ((^(uint16(c.A) ^ value))&(uint16(c.A)^binarySum)&0x0080) > 0)
-
-		// Perform BCD subtraction (A - M - borrow)
-		borrow_in := 1 - uint8(carry) // Convert C flag to borrow (0 or 1)
-
-		// Use int16 for intermediate subtraction to handle potential negative results easily
-		sub_res := int16(c.A) - int16(c.fetchedData) - int16(borrow_in)
-
-		low := (int16(c.A&0x0F) - int16(c.fetchedData&0x0F) - int16(borrow_in))
-		borrow_low := uint8(0)
-		if low < 0 {
-			low -= 6 // BCD adjust low nibble
-			borrow_low = 1
-		}
-
-		high := (int16(c.A>>4) - int16(c.fetchedData>>4) - int16(borrow_low))
-		if high < 0 {
-			high -= 6 // BCD adjust high nibble
-		}
-
-		// Combine nibbles
-		result = (uint8(high&0x0F) << 4) | uint8(low&0x0F)
-		c.A = result
-
-		// Set C flag: Set if result >= 0 (no borrow needed overall)
-		c.setFlag(C, sub_res >= 0)
-		// Set Z flag based on the final BCD result
-		c.setFlag(Z, c.A == 0)
-
-	} else {
-		// --- Binary Mode ---
-		temp = uint16(c.A) + value + carry
-
-		// Set C flag: Based on the carry out of the A + ~M + C addition.
-		// This is equivalent to "no borrow needed" for A - M - (1-C).
-		c.setFlag(C, temp > 0xFF)
-
-		result = uint8(temp & 0x00FF)
-
-		// Set V flag (signed overflow)
-		// V = (A ^ M) & (A ^ R) & 0x80 != 0  (for A - M - B)
-		// Equivalently use A + ~M + C: V = (~(A ^ ~M)) & (A ^ R) & 0x80
-		c.setFlag(V, ((^(uint16(c.A) ^ value))&(uint16(c.A)^temp)&0x0080) > 0)
-
-		// Update Accumulator
-		c.A = result
-
-		// Set Z and N flags based on the result
-		c.setZNFlags(c.A)
+func (c *CPU) sbcDecimal() uint8 {
+	value := uint16(c.fetchedData) ^ 0x00FF
+	var carry uint16 = 0
+	if c.getFlag(C) {
+		carry = 1
 	}
 
-	// SBC potentially requires an extra cycle on page boundary crossing
+	// Calculate binary result for N/V flags
+	binarySum := uint16(c.A) + value + carry
+
+	// Variant-specific N/V flag handling
+	switch c.variant {
+	case VariantNMOS6502:
+		c.setFlag(N, (binarySum&0x80) > 0)
+		c.setFlag(V, ((^(uint16(c.A) ^ value))&(uint16(c.A)^binarySum)&0x0080) > 0)
+	case VariantCMOS65C02:
+		c.setFlag(N, (binarySum&0x80) > 0)
+		c.setFlag(V, ((^(uint16(c.A) ^ value))&(uint16(c.A)^binarySum)&0x0080) > 0)
+	}
+
+	// BCD subtraction (corrected algorithm)
+	borrow_in := 1 - uint8(carry)
+
+	low := int16(c.A&0x0F) - int16(c.fetchedData&0x0F) - int16(borrow_in)
+	borrow_low := uint8(0)
+	if low < 0 {
+		low += 10
+		borrow_low = 1
+	}
+
+	high := int16(c.A>>4) - int16(c.fetchedData>>4) - int16(borrow_low)
+	if high < 0 {
+		high += 10
+		c.setFlag(C, false)
+	} else {
+		c.setFlag(C, true)
+	}
+
+	result := (uint8(high&0x0F) << 4) | uint8(low&0x0F)
+	c.A = result
+	c.setFlag(Z, c.A == 0)
+
 	return 1
 }
 

--- a/cpu_variant_test.go
+++ b/cpu_variant_test.go
@@ -1,0 +1,398 @@
+package cpu6502
+
+import (
+	"testing"
+)
+
+// setupCPUWithVariant creates a CPU instance with a specific variant for testing
+func setupCPUWithVariant(variant CPUVariant) (*CPU, *MockBus) {
+	bus := NewMockBus()
+	cpu := NewCPUWithVariant(bus, variant)
+	// Set reset/irq/nmi vectors for safety during tests
+	bus.Write(0xFFFA, 0x00)
+	bus.Write(0xFFFB, 0xF0) // NMI -> F000
+	bus.Write(0xFFFC, 0x00)
+	bus.Write(0xFFFD, 0xF1) // Reset -> F100
+	bus.Write(0xFFFE, 0x00)
+	bus.Write(0xFFFF, 0xF2) // IRQ/BRK -> F200
+	return cpu, bus
+}
+
+// TestVariantProperties verifies the basic properties of each variant
+func TestVariantProperties(t *testing.T) {
+	tests := []struct {
+		variant             CPUVariant
+		name                string
+		supportsDecimalMode bool
+		hasIndirectJMPBug   bool
+	}{
+		{VariantNMOS6502, "NMOS 6502", true, true},
+		{VariantCMOS65C02, "CMOS 65C02", true, false},
+		{VariantRicoh2A03, "Ricoh 2A03 (NTSC)", false, true},
+		{VariantRicoh2A07, "Ricoh 2A07 (PAL)", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.variant.String() != tt.name {
+				t.Errorf("String() = %q, want %q", tt.variant.String(), tt.name)
+			}
+			if tt.variant.SupportsDecimalMode() != tt.supportsDecimalMode {
+				t.Errorf("SupportsDecimalMode() = %v, want %v",
+					tt.variant.SupportsDecimalMode(), tt.supportsDecimalMode)
+			}
+			if tt.variant.HasIndirectJMPBug() != tt.hasIndirectJMPBug {
+				t.Errorf("HasIndirectJMPBug() = %v, want %v",
+					tt.variant.HasIndirectJMPBug(), tt.hasIndirectJMPBug)
+			}
+		})
+	}
+}
+
+// TestVariantConstructors verifies CPU construction with variants
+func TestVariantConstructors(t *testing.T) {
+	bus := NewMockBus()
+
+	t.Run("NewCPU defaults to NMOS", func(t *testing.T) {
+		cpu := NewCPU(bus)
+		if cpu.Variant() != VariantNMOS6502 {
+			t.Errorf("NewCPU() variant = %v, want %v", cpu.Variant(), VariantNMOS6502)
+		}
+	})
+
+	t.Run("NewCPUWithVariant sets variant", func(t *testing.T) {
+		variants := []CPUVariant{
+			VariantNMOS6502,
+			VariantCMOS65C02,
+			VariantRicoh2A03,
+			VariantRicoh2A07,
+		}
+		for _, variant := range variants {
+			cpu := NewCPUWithVariant(bus, variant)
+			if cpu.Variant() != variant {
+				t.Errorf("NewCPUWithVariant(%v) variant = %v, want %v",
+					variant, cpu.Variant(), variant)
+			}
+		}
+	})
+
+	t.Run("NewCPUWithErrorHandler defaults to NMOS", func(t *testing.T) {
+		cpu := NewCPUWithErrorHandler(bus, &StrictErrorHandler{})
+		if cpu.Variant() != VariantNMOS6502 {
+			t.Errorf("NewCPUWithErrorHandler() variant = %v, want %v",
+				cpu.Variant(), VariantNMOS6502)
+		}
+	})
+
+	t.Run("NewCPUWithVariantAndErrorHandler sets both", func(t *testing.T) {
+		handler := &StrictErrorHandler{}
+		cpu := NewCPUWithVariantAndErrorHandler(bus, VariantCMOS65C02, handler)
+		if cpu.Variant() != VariantCMOS65C02 {
+			t.Errorf("variant = %v, want %v", cpu.Variant(), VariantCMOS65C02)
+		}
+	})
+}
+
+// TestIndirectJMPBug tests the page boundary bug behavior across variants
+func TestIndirectJMPBug(t *testing.T) {
+	variants := []struct {
+		variant CPUVariant
+		hasBug  bool
+	}{
+		{VariantNMOS6502, true},
+		{VariantCMOS65C02, false},
+		{VariantRicoh2A03, true},
+		{VariantRicoh2A07, true},
+	}
+
+	for _, tt := range variants {
+		t.Run(tt.variant.String(), func(t *testing.T) {
+			cpu, bus := setupCPUWithVariant(tt.variant)
+
+			// Set up JMP ($10FF) where low byte is $FF
+			indirectAddr := uint16(0x10FF)
+			targetLow := uint8(0x34)
+			targetHigh := uint8(0x12)
+
+			// Program: JMP ($10FF)
+			program := []uint8{
+				0x6C,                     // JMP Indirect
+				uint8(indirectAddr),      // Low byte ($FF)
+				uint8(indirectAddr >> 8), // High byte ($10)
+				0x00,                     // BRK
+			}
+
+			baseAddr := uint16(0x8000)
+			bus.load(baseAddr, program)
+
+			// Set up pointer bytes
+			bus.Write(indirectAddr, targetLow)         // $10FF = $34
+			bus.Write(indirectAddr&0xFF00, targetHigh) // $1000 = $12 (bug location)
+			bus.Write(indirectAddr+1, 0xEE)            // $1100 = $EE (correct location)
+
+			cpu.PC = baseAddr
+			cpu.Cycles = 0
+
+			runCycles(cpu, 5)
+
+			var expectedPC uint16
+			if tt.hasBug {
+				// Bug: reads high byte from $1000 instead of $1100
+				expectedPC = uint16(targetHigh)<<8 | uint16(targetLow) // $1234
+			} else {
+				// Fixed: reads high byte from $1100
+				expectedPC = uint16(0xEE)<<8 | uint16(targetLow) // $EE34
+			}
+
+			if cpu.PC != expectedPC {
+				t.Errorf("%s: JMP bug test failed. Expected PC=$%04X, got PC=$%04X",
+					tt.variant.String(), expectedPC, cpu.PC)
+			}
+		})
+	}
+}
+
+// TestDecimalModeSupport tests decimal mode behavior across variants
+func TestDecimalModeSupport(t *testing.T) {
+	variants := []struct {
+		variant  CPUVariant
+		supports bool
+	}{
+		{VariantNMOS6502, true},
+		{VariantCMOS65C02, true},
+		{VariantRicoh2A03, false},
+		{VariantRicoh2A07, false},
+	}
+
+	for _, tt := range variants {
+		t.Run(tt.variant.String()+" ADC", func(t *testing.T) {
+			cpu, bus := setupCPUWithVariant(tt.variant)
+
+			// Test: 09 + 01 in decimal mode should give 10 (BCD)
+			// or 0A (binary) if decimal mode is disabled
+			cpu.A = 0x09
+			cpu.setFlag(D, true) // Enable decimal mode
+			cpu.setFlag(C, false)
+
+			program := []uint8{0x69, 0x01, 0x00} // ADC #$01, BRK
+			baseAddr := uint16(0x8000)
+			bus.load(baseAddr, program)
+			cpu.PC = baseAddr
+			cpu.Cycles = 0
+
+			runCycles(cpu, 2)
+
+			var expectedA uint8
+			if tt.supports {
+				expectedA = 0x10 // BCD result
+			} else {
+				expectedA = 0x0A // Binary result (decimal mode ignored)
+			}
+
+			if cpu.A != expectedA {
+				t.Errorf("%s: ADC decimal test failed. Expected A=$%02X, got A=$%02X",
+					tt.variant.String(), expectedA, cpu.A)
+			}
+		})
+
+		t.Run(tt.variant.String()+" SBC", func(t *testing.T) {
+			cpu, bus := setupCPUWithVariant(tt.variant)
+
+			// Test: 10 - 01 in decimal mode should give 09 (BCD)
+			// or 0F (binary) if decimal mode is disabled
+			cpu.A = 0x10
+			cpu.setFlag(D, true) // Enable decimal mode
+			cpu.setFlag(C, true) // No borrow
+
+			program := []uint8{0xE9, 0x01, 0x00} // SBC #$01, BRK
+			baseAddr := uint16(0x8000)
+			bus.load(baseAddr, program)
+			cpu.PC = baseAddr
+			cpu.Cycles = 0
+
+			runCycles(cpu, 2)
+
+			var expectedA uint8
+			if tt.supports {
+				expectedA = 0x09 // BCD result
+			} else {
+				expectedA = 0x0F // Binary result (decimal mode ignored)
+			}
+
+			if cpu.A != expectedA {
+				t.Errorf("%s: SBC decimal test failed. Expected A=$%02X, got A=$%02X",
+					tt.variant.String(), expectedA, cpu.A)
+			}
+		})
+	}
+}
+
+// TestDecimalModeADCEdgeCases tests edge cases in decimal mode ADC
+func TestDecimalModeADCEdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		a         uint8
+		operand   uint8
+		carryIn   bool
+		expectedA uint8
+		expectedC bool
+		expectedZ bool
+	}{
+		{"99+1 C=0", 0x99, 0x01, false, 0x00, true, true},
+		{"99+0 C=1", 0x99, 0x00, true, 0x00, true, true},
+		{"50+50 C=0", 0x50, 0x50, false, 0x00, true, true},
+		{"09+1 C=0", 0x09, 0x01, false, 0x10, false, false},
+		{"09+1 C=1", 0x09, 0x01, true, 0x11, false, false},
+		{"00+00 C=0", 0x00, 0x00, false, 0x00, false, true},
+		{"00+00 C=1", 0x00, 0x00, true, 0x01, false, false},
+	}
+
+	// Test only variants that support decimal mode
+	variants := []CPUVariant{VariantNMOS6502, VariantCMOS65C02}
+
+	for _, variant := range variants {
+		for _, tt := range tests {
+			t.Run(variant.String()+" "+tt.name, func(t *testing.T) {
+				cpu, bus := setupCPUWithVariant(variant)
+
+				cpu.A = tt.a
+				cpu.setFlag(D, true)
+				cpu.setFlag(C, tt.carryIn)
+
+				program := []uint8{0x69, tt.operand, 0x00} // ADC #operand, BRK
+				baseAddr := uint16(0x8000)
+				bus.load(baseAddr, program)
+				cpu.PC = baseAddr
+				cpu.Cycles = 0
+
+				runCycles(cpu, 2)
+
+				if cpu.A != tt.expectedA {
+					t.Errorf("Expected A=$%02X, got A=$%02X", tt.expectedA, cpu.A)
+				}
+				if cpu.getFlag(C) != tt.expectedC {
+					t.Errorf("Expected C=%v, got C=%v", tt.expectedC, cpu.getFlag(C))
+				}
+				if cpu.getFlag(Z) != tt.expectedZ {
+					t.Errorf("Expected Z=%v, got Z=%v", tt.expectedZ, cpu.getFlag(Z))
+				}
+			})
+		}
+	}
+}
+
+// TestDecimalModeSBCEdgeCases tests edge cases in decimal mode SBC
+func TestDecimalModeSBCEdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		a         uint8
+		operand   uint8
+		carryIn   bool
+		expectedA uint8
+		expectedC bool
+		expectedZ bool
+	}{
+		{"00-1 C=1", 0x00, 0x01, true, 0x99, false, false},
+		{"00-1 C=0", 0x00, 0x01, false, 0x98, false, false},
+		{"10-1 C=1", 0x10, 0x01, true, 0x09, true, false},
+		{"10-1 C=0", 0x10, 0x01, false, 0x08, true, false},
+		{"00-0 C=1", 0x00, 0x00, true, 0x00, true, true},
+	}
+
+	// Test only variants that support decimal mode
+	variants := []CPUVariant{VariantNMOS6502, VariantCMOS65C02}
+
+	for _, variant := range variants {
+		for _, tt := range tests {
+			t.Run(variant.String()+" "+tt.name, func(t *testing.T) {
+				cpu, bus := setupCPUWithVariant(variant)
+
+				cpu.A = tt.a
+				cpu.setFlag(D, true)
+				cpu.setFlag(C, tt.carryIn)
+
+				program := []uint8{0xE9, tt.operand, 0x00} // SBC #operand, BRK
+				baseAddr := uint16(0x8000)
+				bus.load(baseAddr, program)
+				cpu.PC = baseAddr
+				cpu.Cycles = 0
+
+				runCycles(cpu, 2)
+
+				if cpu.A != tt.expectedA {
+					t.Errorf("Expected A=$%02X, got A=$%02X", tt.expectedA, cpu.A)
+				}
+				if cpu.getFlag(C) != tt.expectedC {
+					t.Errorf("Expected C=%v, got C=%v", tt.expectedC, cpu.getFlag(C))
+				}
+				if cpu.getFlag(Z) != tt.expectedZ {
+					t.Errorf("Expected Z=%v, got Z=%v", tt.expectedZ, cpu.getFlag(Z))
+				}
+			})
+		}
+	}
+}
+
+// TestVariantNVFlagsInDecimalMode tests N/V flag behavior in decimal mode
+func TestVariantNVFlagsInDecimalMode(t *testing.T) {
+	// Both NMOS and CMOS set N/V based on binary intermediate result
+	variants := []CPUVariant{VariantNMOS6502, VariantCMOS65C02}
+
+	for _, variant := range variants {
+		t.Run(variant.String()+" ADC N/V flags", func(t *testing.T) {
+			cpu, bus := setupCPUWithVariant(variant)
+
+			// Test: 0x70 + 0x10 = 0x80 (BCD)
+			// Binary: 0x70 + 0x10 = 0x80 -> N=1, V=1 (pos+pos=neg overflow)
+			cpu.A = 0x70
+			cpu.setFlag(D, true)
+			cpu.setFlag(C, false)
+
+			program := []uint8{0x69, 0x10, 0x00} // ADC #$10, BRK
+			baseAddr := uint16(0x8000)
+			bus.load(baseAddr, program)
+			cpu.PC = baseAddr
+			cpu.Cycles = 0
+
+			runCycles(cpu, 2)
+
+			if cpu.A != 0x80 {
+				t.Errorf("Expected A=$80, got A=$%02X", cpu.A)
+			}
+			if !cpu.getFlag(N) {
+				t.Error("Expected N=1 (based on binary intermediate)")
+			}
+			if !cpu.getFlag(V) {
+				t.Error("Expected V=1 (based on binary intermediate)")
+			}
+		})
+
+		t.Run(variant.String()+" SBC N/V flags", func(t *testing.T) {
+			cpu, bus := setupCPUWithVariant(variant)
+
+			// Test: 0x50 - 0x50 = 0x00 (BCD)
+			// Binary: 0x50 + 0xAF + 1 = 0x100 -> N=0, V=0
+			cpu.A = 0x50
+			cpu.setFlag(D, true)
+			cpu.setFlag(C, true)
+
+			program := []uint8{0xE9, 0x50, 0x00} // SBC #$50, BRK
+			baseAddr := uint16(0x8000)
+			bus.load(baseAddr, program)
+			cpu.PC = baseAddr
+			cpu.Cycles = 0
+
+			runCycles(cpu, 2)
+
+			if cpu.A != 0x00 {
+				t.Errorf("Expected A=$00, got A=$%02X", cpu.A)
+			}
+			if cpu.getFlag(N) {
+				t.Error("Expected N=0 (based on binary intermediate)")
+			}
+			if cpu.getFlag(V) {
+				t.Error("Expected V=0 (based on binary intermediate)")
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Define CPUVariant type (NMOS 6502, CMOS 65C02, Ricoh 2A03/2A07)
- Add variant-specific behavior methods (SupportsDecimalMode, HasIndirectJMPBug)
- Update CPU struct with variant field
- Add NewCPUWithVariant and NewCPUWithVariantAndErrorHandler constructors
- Fix ADC decimal mode with corrected carry detection algorithm
- Fix SBC decimal mode with corrected borrow detection algorithm
- Update IND addressing mode to handle page boundary bug per variant
- Add comprehensive variant-specific tests
- All tests pass (existing and new)

Implements plandocs/04-high-priority-cpu-variant-support.md Implements plandocs/03-high-priority-decimal-mode-fixes.md