### PR TITLE
Implement page cross cycle accuracy

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -230,13 +230,14 @@ type CPU struct {
 
 // Instruction struct: Use method expressions for types
 type Instruction struct {
-	Name         string           // Mnemonic (e.g., "LDA")
-	Operate      func(*CPU) uint8 // Function to execute the instruction's logic (accepts *CPU)
-	AddrMode     func(*CPU) uint8 // Function to calculate the address and fetch data (accepts *CPU)
-	AddrModeType AddrModeType     // Type of addressing mode
-	Cycles       uint8            // Base cycles for this instruction/mode
-	Length       uint8            // Length of the instruction in bytes
-	Illegal      bool             // Whether this is an official or unofficial/illegal opcode
+	Name             string           // Mnemonic (e.g., "LDA")
+	Operate          func(*CPU) uint8 // Function to execute the instruction's logic (accepts *CPU)
+	AddrMode         func(*CPU) uint8 // Function to calculate the address and fetch data (accepts *CPU)
+	AddrModeType     AddrModeType     // Type of addressing mode
+	Cycles           uint8            // Base cycles for this instruction/mode
+	Length           uint8            // Length of the instruction in bytes
+	Illegal          bool             // Whether this is an official or unofficial/illegal opcode
+	PageCrossPenalty bool             // Whether to add +1 cycle on page boundary cross
 }
 
 // NewCPU creates a new CPU with default configuration
@@ -560,7 +561,7 @@ func (c *CPU) adcBinary(carry uint16) uint8 {
 	c.setFlag(V, ((^(uint16(c.A) ^ uint16(c.fetchedData)))&(uint16(c.A)^temp)&0x0080) > 0)
 	c.A = result
 	c.setZNFlags(c.A)
-	return 1
+	return 0
 }
 
 func (c *CPU) adcDecimal(carry uint16) uint8 {
@@ -599,14 +600,14 @@ func (c *CPU) adcDecimal(carry uint16) uint8 {
 	c.A = result
 	c.setFlag(Z, c.A == 0)
 
-	return 1
+	return 0
 }
 
 func (c *CPU) AND() uint8 {
 	c.fetchDataIfNeeded()
 	c.A &= c.fetchedData
 	c.setZNFlags(c.A)
-	return 1
+	return 0
 }
 
 // ASL - Arithmetic Shift Left
@@ -709,7 +710,7 @@ func (c *CPU) CMP() uint8 {
 	temp := uint16(c.A) - uint16(c.fetchedData)
 	c.setFlag(C, c.A >= c.fetchedData)
 	c.setZNFlags(uint8(temp & 0x00FF))
-	return 1
+	return 0
 }
 
 func (c *CPU) CPX() uint8 {
@@ -743,7 +744,7 @@ func (c *CPU) EOR() uint8 {
 	c.fetchDataIfNeeded()
 	c.A ^= c.fetchedData
 	c.setZNFlags(c.A)
-	return 1
+	return 0
 }
 
 func (c *CPU) INC() uint8 {
@@ -773,21 +774,21 @@ func (c *CPU) LDA() uint8 {
 	c.fetchDataIfNeeded()
 	c.A = c.fetchedData
 	c.setZNFlags(c.A)
-	return 1
+	return 0
 }
 
 func (c *CPU) LDX() uint8 {
 	c.fetchDataIfNeeded()
 	c.X = c.fetchedData
 	c.setZNFlags(c.X)
-	return 1
+	return 0
 }
 
 func (c *CPU) LDY() uint8 {
 	c.fetchDataIfNeeded()
 	c.Y = c.fetchedData
 	c.setZNFlags(c.Y)
-	return 1
+	return 0
 }
 
 // LSR - Logical Shift Right
@@ -810,30 +811,15 @@ func (c *CPU) LSR() uint8 {
 
 // NOP - No Operation
 func (c *CPU) NOP() uint8 {
-	// Some unofficial NOPs using indexed addressing might technically read
-	// from memory, potentially causing a page cross and taking an extra cycle.
-	// We handle this by having the addressing mode function return 1 if a cross occurs,
-	// and returning 1 from here allows that cycle to be added.
-	// Official NOP (EA) and simple unofficial NOPs (IMP, IMM, ZP0) don't have this.
-	switch c.opcode {
-	// NOPs with ABX addressing mode that can cross pages:
-	case 0x1C, 0x3C, 0x5C, 0x7C, 0xDC, 0xFC:
-		// These modes *do* calculate an address, even if not used.
-		// Fetch might not be strictly necessary for NOP, but the address calc is.
-		// The AddrMode function already returns 1 on page cross.
-		return 1 // Signal that page cross cycle might apply
-	// NOPs with IZY addressing mode that can cross pages:
-	// (None documented, but if added, would need similar handling)
-	default:
-		return 0 // No potential for extra cycle from page cross
-	}
+	// Page cross handling is now done via PageCrossPenalty field in lookup table
+	return 0
 }
 
 func (c *CPU) ORA() uint8 {
 	c.fetchDataIfNeeded()
 	c.A |= c.fetchedData
 	c.setZNFlags(c.A)
-	return 1
+	return 0
 }
 
 func (c *CPU) PHA() uint8 { c.push(c.A); return 0 }
@@ -946,7 +932,7 @@ func (c *CPU) sbcBinary() uint8 {
 	c.A = result
 	c.setZNFlags(c.A)
 
-	return 1
+	return 0
 }
 
 func (c *CPU) sbcDecimal() uint8 {
@@ -991,7 +977,7 @@ func (c *CPU) sbcDecimal() uint8 {
 	c.A = result
 	c.setFlag(Z, c.A == 0)
 
-	return 1
+	return 0
 }
 
 func (c *CPU) SEC() uint8 { c.setFlag(C, true); return 0 }
@@ -1032,6 +1018,31 @@ func (c *CPU) buildLookupTable() {
 	ABX := (*CPU).ABX
 	ABY := (*CPU).ABY
 	IND := (*CPU).IND
+	// Page Cross Penalty Reference
+	//
+	// The 6502 CPU has different cycle timing behavior when indexed addressing modes
+	// (ABX, ABY, IZY) cross page boundaries. A page boundary is crossed when the
+	// high byte of the effective address differs from the high byte of the base address.
+	//
+	// Instructions that ADD +1 cycle on page boundary cross:
+	//   - Load: LDA, LDX, LDY (ABX, ABY, IZY modes)
+	//   - Logic: AND, EOR, ORA (ABX, ABY, IZY modes)
+	//   - Arithmetic: ADC, SBC (ABX, ABY, IZY modes)
+	//   - Compare: CMP (ABX, ABY, IZY modes)
+	//   - Unofficial: *NOP with ABX addressing (opcodes 0x1C, 0x3C, 0x5C, 0x7C, 0xDC, 0xFC)
+	//
+	// Instructions that DO NOT add cycle on page cross (always use full cycles):
+	//   - Store: STA, STX, STY (always take 5/6 cycles regardless of page cross)
+	//   - Read-Modify-Write: ASL, LSR, ROL, ROR, INC, DEC (always take 7 cycles with ABX)
+	//   - CPX, CPY (no indexed modes that can cross pages)
+	//
+	// Addressing modes that can cross pages:
+	//   - ABX (Absolute,X): effective = base + X
+	//   - ABY (Absolute,Y): effective = base + Y
+	//   - IZY (Indirect,Y): effective = [zp] + Y
+	//
+	// Page cross detection: (effective & 0xFF00) != (base & 0xFF00)
+	//
 	IZX := (*CPU).IZX
 	IZY := (*CPU).IZY
 
@@ -1095,223 +1106,236 @@ func (c *CPU) buildLookupTable() {
 
 	// Fill with illegal opcodes first
 	for i := range c.lookup {
-		c.lookup[i] = Instruction{Name: "XXX", Operate: XXX, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Illegal: true}
+		c.lookup[i] = Instruction{Name: "XXX", Operate: XXX, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Illegal: true, PageCrossPenalty: false}
 	}
 
 	// --- Official Opcodes --- Using the helper variables above
-	c.lookup[0xA9] = Instruction{Name: "LDA", Operate: LDA, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0xA5] = Instruction{Name: "LDA", Operate: LDA, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0xB5] = Instruction{Name: "LDA", Operate: LDA, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2}
-	c.lookup[0xAD] = Instruction{Name: "LDA", Operate: LDA, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
-	c.lookup[0xBD] = Instruction{Name: "LDA", Operate: LDA, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3}
-	c.lookup[0xB9] = Instruction{Name: "LDA", Operate: LDA, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3}
-	c.lookup[0xA1] = Instruction{Name: "LDA", Operate: LDA, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2}
-	c.lookup[0xB1] = Instruction{Name: "LDA", Operate: LDA, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2}
+	// Load instructions - ADD page cross penalty for indexed modes
+	c.lookup[0xA9] = Instruction{Name: "LDA", Operate: LDA, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xA5] = Instruction{Name: "LDA", Operate: LDA, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xB5] = Instruction{Name: "LDA", Operate: LDA, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xAD] = Instruction{Name: "LDA", Operate: LDA, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
+	c.lookup[0xBD] = Instruction{Name: "LDA", Operate: LDA, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0xB9] = Instruction{Name: "LDA", Operate: LDA, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0xA1] = Instruction{Name: "LDA", Operate: LDA, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xB1] = Instruction{Name: "LDA", Operate: LDA, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2, PageCrossPenalty: true}
 
-	c.lookup[0xA2] = Instruction{Name: "LDX", Operate: LDX, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0xA6] = Instruction{Name: "LDX", Operate: LDX, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0xB6] = Instruction{Name: "LDX", Operate: LDX, AddrMode: ZPY, AddrModeType: AddrModeZPY, Cycles: 4, Length: 2}
-	c.lookup[0xAE] = Instruction{Name: "LDX", Operate: LDX, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
-	c.lookup[0xBE] = Instruction{Name: "LDX", Operate: LDX, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3}
+	c.lookup[0xA2] = Instruction{Name: "LDX", Operate: LDX, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xA6] = Instruction{Name: "LDX", Operate: LDX, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xB6] = Instruction{Name: "LDX", Operate: LDX, AddrMode: ZPY, AddrModeType: AddrModeZPY, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xAE] = Instruction{Name: "LDX", Operate: LDX, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
+	c.lookup[0xBE] = Instruction{Name: "LDX", Operate: LDX, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3, PageCrossPenalty: true}
 
-	c.lookup[0xA0] = Instruction{Name: "LDY", Operate: LDY, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0xA4] = Instruction{Name: "LDY", Operate: LDY, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0xB4] = Instruction{Name: "LDY", Operate: LDY, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2}
-	c.lookup[0xAC] = Instruction{Name: "LDY", Operate: LDY, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
-	c.lookup[0xBC] = Instruction{Name: "LDY", Operate: LDY, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3}
+	c.lookup[0xA0] = Instruction{Name: "LDY", Operate: LDY, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xA4] = Instruction{Name: "LDY", Operate: LDY, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xB4] = Instruction{Name: "LDY", Operate: LDY, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xAC] = Instruction{Name: "LDY", Operate: LDY, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
+	c.lookup[0xBC] = Instruction{Name: "LDY", Operate: LDY, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, PageCrossPenalty: true}
 
-	c.lookup[0x85] = Instruction{Name: "STA", Operate: STA, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0x95] = Instruction{Name: "STA", Operate: STA, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2}
-	c.lookup[0x8D] = Instruction{Name: "STA", Operate: STA, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
-	c.lookup[0x9D] = Instruction{Name: "STA", Operate: STA, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 5, Length: 3}
-	c.lookup[0x99] = Instruction{Name: "STA", Operate: STA, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 5, Length: 3}
-	c.lookup[0x81] = Instruction{Name: "STA", Operate: STA, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2}
-	c.lookup[0x91] = Instruction{Name: "STA", Operate: STA, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 6, Length: 2}
+	// Store instructions - NO page cross penalty (always use full cycles)
+	c.lookup[0x85] = Instruction{Name: "STA", Operate: STA, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x95] = Instruction{Name: "STA", Operate: STA, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x8D] = Instruction{Name: "STA", Operate: STA, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x9D] = Instruction{Name: "STA", Operate: STA, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 5, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x99] = Instruction{Name: "STA", Operate: STA, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 5, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x81] = Instruction{Name: "STA", Operate: STA, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x91] = Instruction{Name: "STA", Operate: STA, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 6, Length: 2, PageCrossPenalty: false}
 
-	c.lookup[0x86] = Instruction{Name: "STX", Operate: STX, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0x96] = Instruction{Name: "STX", Operate: STX, AddrMode: ZPY, AddrModeType: AddrModeZPY, Cycles: 4, Length: 2}
-	c.lookup[0x8E] = Instruction{Name: "STX", Operate: STX, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
+	c.lookup[0x86] = Instruction{Name: "STX", Operate: STX, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x96] = Instruction{Name: "STX", Operate: STX, AddrMode: ZPY, AddrModeType: AddrModeZPY, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x8E] = Instruction{Name: "STX", Operate: STX, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
 
-	c.lookup[0x84] = Instruction{Name: "STY", Operate: STY, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0x94] = Instruction{Name: "STY", Operate: STY, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2}
-	c.lookup[0x8C] = Instruction{Name: "STY", Operate: STY, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
+	c.lookup[0x84] = Instruction{Name: "STY", Operate: STY, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x94] = Instruction{Name: "STY", Operate: STY, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x8C] = Instruction{Name: "STY", Operate: STY, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
 
-	c.lookup[0xAA] = Instruction{Name: "TAX", Operate: TAX, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0xA8] = Instruction{Name: "TAY", Operate: TAY, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0xBA] = Instruction{Name: "TSX", Operate: TSX, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x8A] = Instruction{Name: "TXA", Operate: TXA, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x9A] = Instruction{Name: "TXS", Operate: TXS, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x98] = Instruction{Name: "TYA", Operate: TYA, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
+	// Transfer and stack instructions - no page cross possible
+	c.lookup[0xAA] = Instruction{Name: "TAX", Operate: TAX, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0xA8] = Instruction{Name: "TAY", Operate: TAY, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0xBA] = Instruction{Name: "TSX", Operate: TSX, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x8A] = Instruction{Name: "TXA", Operate: TXA, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x9A] = Instruction{Name: "TXS", Operate: TXS, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x98] = Instruction{Name: "TYA", Operate: TYA, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
 
-	c.lookup[0x48] = Instruction{Name: "PHA", Operate: PHA, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 3, Length: 1}
-	c.lookup[0x08] = Instruction{Name: "PHP", Operate: PHP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 3, Length: 1}
-	c.lookup[0x68] = Instruction{Name: "PLA", Operate: PLA, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 4, Length: 1}
-	c.lookup[0x28] = Instruction{Name: "PLP", Operate: PLP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 4, Length: 1}
+	c.lookup[0x48] = Instruction{Name: "PHA", Operate: PHA, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 3, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x08] = Instruction{Name: "PHP", Operate: PHP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 3, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x68] = Instruction{Name: "PLA", Operate: PLA, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 4, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x28] = Instruction{Name: "PLP", Operate: PLP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 4, Length: 1, PageCrossPenalty: false}
 
-	c.lookup[0x69] = Instruction{Name: "ADC", Operate: ADC, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0x65] = Instruction{Name: "ADC", Operate: ADC, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0x75] = Instruction{Name: "ADC", Operate: ADC, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2}
-	c.lookup[0x6D] = Instruction{Name: "ADC", Operate: ADC, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
-	c.lookup[0x7D] = Instruction{Name: "ADC", Operate: ADC, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3}
-	c.lookup[0x79] = Instruction{Name: "ADC", Operate: ADC, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3}
-	c.lookup[0x61] = Instruction{Name: "ADC", Operate: ADC, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2}
-	c.lookup[0x71] = Instruction{Name: "ADC", Operate: ADC, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2}
+	// Arithmetic instructions - ADD page cross penalty for indexed modes
+	c.lookup[0x69] = Instruction{Name: "ADC", Operate: ADC, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x65] = Instruction{Name: "ADC", Operate: ADC, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x75] = Instruction{Name: "ADC", Operate: ADC, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x6D] = Instruction{Name: "ADC", Operate: ADC, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x7D] = Instruction{Name: "ADC", Operate: ADC, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0x79] = Instruction{Name: "ADC", Operate: ADC, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0x61] = Instruction{Name: "ADC", Operate: ADC, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x71] = Instruction{Name: "ADC", Operate: ADC, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2, PageCrossPenalty: true}
 
-	c.lookup[0xE9] = Instruction{Name: "SBC", Operate: SBC, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0xE5] = Instruction{Name: "SBC", Operate: SBC, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0xF5] = Instruction{Name: "SBC", Operate: SBC, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2}
-	c.lookup[0xED] = Instruction{Name: "SBC", Operate: SBC, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
-	c.lookup[0xFD] = Instruction{Name: "SBC", Operate: SBC, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3}
-	c.lookup[0xF9] = Instruction{Name: "SBC", Operate: SBC, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3}
-	c.lookup[0xE1] = Instruction{Name: "SBC", Operate: SBC, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2}
-	c.lookup[0xF1] = Instruction{Name: "SBC", Operate: SBC, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2}
+	c.lookup[0xE9] = Instruction{Name: "SBC", Operate: SBC, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xE5] = Instruction{Name: "SBC", Operate: SBC, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xF5] = Instruction{Name: "SBC", Operate: SBC, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xED] = Instruction{Name: "SBC", Operate: SBC, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
+	c.lookup[0xFD] = Instruction{Name: "SBC", Operate: SBC, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0xF9] = Instruction{Name: "SBC", Operate: SBC, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0xE1] = Instruction{Name: "SBC", Operate: SBC, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xF1] = Instruction{Name: "SBC", Operate: SBC, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2, PageCrossPenalty: true}
 
-	c.lookup[0xE6] = Instruction{Name: "INC", Operate: INC, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2}
-	c.lookup[0xF6] = Instruction{Name: "INC", Operate: INC, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2}
-	c.lookup[0xEE] = Instruction{Name: "INC", Operate: INC, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3}
-	c.lookup[0xFE] = Instruction{Name: "INC", Operate: INC, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3}
-	c.lookup[0xE8] = Instruction{Name: "INX", Operate: INX, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0xC8] = Instruction{Name: "INY", Operate: INY, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
+	// Read-modify-write instructions - NO page cross penalty (always use full cycles)
+	c.lookup[0xE6] = Instruction{Name: "INC", Operate: INC, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xF6] = Instruction{Name: "INC", Operate: INC, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xEE] = Instruction{Name: "INC", Operate: INC, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3, PageCrossPenalty: false}
+	c.lookup[0xFE] = Instruction{Name: "INC", Operate: INC, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3, PageCrossPenalty: false}
+	c.lookup[0xE8] = Instruction{Name: "INX", Operate: INX, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0xC8] = Instruction{Name: "INY", Operate: INY, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
 
-	c.lookup[0xC6] = Instruction{Name: "DEC", Operate: DEC, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2}
-	c.lookup[0xD6] = Instruction{Name: "DEC", Operate: DEC, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2}
-	c.lookup[0xCE] = Instruction{Name: "DEC", Operate: DEC, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3}
-	c.lookup[0xDE] = Instruction{Name: "DEC", Operate: DEC, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3}
-	c.lookup[0xCA] = Instruction{Name: "DEX", Operate: DEX, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x88] = Instruction{Name: "DEY", Operate: DEY, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
+	c.lookup[0xC6] = Instruction{Name: "DEC", Operate: DEC, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xD6] = Instruction{Name: "DEC", Operate: DEC, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xCE] = Instruction{Name: "DEC", Operate: DEC, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3, PageCrossPenalty: false}
+	c.lookup[0xDE] = Instruction{Name: "DEC", Operate: DEC, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3, PageCrossPenalty: false}
+	c.lookup[0xCA] = Instruction{Name: "DEX", Operate: DEX, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x88] = Instruction{Name: "DEY", Operate: DEY, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
 
-	c.lookup[0x0A] = Instruction{Name: "ASL", Operate: ASL, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x06] = Instruction{Name: "ASL", Operate: ASL, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2}
-	c.lookup[0x16] = Instruction{Name: "ASL", Operate: ASL, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2}
-	c.lookup[0x0E] = Instruction{Name: "ASL", Operate: ASL, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3}
-	c.lookup[0x1E] = Instruction{Name: "ASL", Operate: ASL, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3}
+	c.lookup[0x0A] = Instruction{Name: "ASL", Operate: ASL, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x06] = Instruction{Name: "ASL", Operate: ASL, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x16] = Instruction{Name: "ASL", Operate: ASL, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x0E] = Instruction{Name: "ASL", Operate: ASL, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x1E] = Instruction{Name: "ASL", Operate: ASL, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3, PageCrossPenalty: false}
 
-	c.lookup[0x4A] = Instruction{Name: "LSR", Operate: LSR, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x46] = Instruction{Name: "LSR", Operate: LSR, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2}
-	c.lookup[0x56] = Instruction{Name: "LSR", Operate: LSR, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2}
-	c.lookup[0x4E] = Instruction{Name: "LSR", Operate: LSR, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3}
-	c.lookup[0x5E] = Instruction{Name: "LSR", Operate: LSR, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3}
+	c.lookup[0x4A] = Instruction{Name: "LSR", Operate: LSR, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x46] = Instruction{Name: "LSR", Operate: LSR, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x56] = Instruction{Name: "LSR", Operate: LSR, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x4E] = Instruction{Name: "LSR", Operate: LSR, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x5E] = Instruction{Name: "LSR", Operate: LSR, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3, PageCrossPenalty: false}
 
-	c.lookup[0x2A] = Instruction{Name: "ROL", Operate: ROL, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x26] = Instruction{Name: "ROL", Operate: ROL, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2}
-	c.lookup[0x36] = Instruction{Name: "ROL", Operate: ROL, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2}
-	c.lookup[0x2E] = Instruction{Name: "ROL", Operate: ROL, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3}
-	c.lookup[0x3E] = Instruction{Name: "ROL", Operate: ROL, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3}
+	c.lookup[0x2A] = Instruction{Name: "ROL", Operate: ROL, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x26] = Instruction{Name: "ROL", Operate: ROL, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x36] = Instruction{Name: "ROL", Operate: ROL, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x2E] = Instruction{Name: "ROL", Operate: ROL, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x3E] = Instruction{Name: "ROL", Operate: ROL, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3, PageCrossPenalty: false}
 
-	c.lookup[0x6A] = Instruction{Name: "ROR", Operate: ROR, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x66] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2}
-	c.lookup[0x76] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2}
-	c.lookup[0x6E] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3}
-	c.lookup[0x7E] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3}
+	c.lookup[0x6A] = Instruction{Name: "ROR", Operate: ROR, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x66] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x76] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x6E] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x7E] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3, PageCrossPenalty: false}
 
-	c.lookup[0x29] = Instruction{Name: "AND", Operate: AND, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0x25] = Instruction{Name: "AND", Operate: AND, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0x35] = Instruction{Name: "AND", Operate: AND, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2}
-	c.lookup[0x2D] = Instruction{Name: "AND", Operate: AND, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
-	c.lookup[0x3D] = Instruction{Name: "AND", Operate: AND, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3}
-	c.lookup[0x39] = Instruction{Name: "AND", Operate: AND, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3}
-	c.lookup[0x21] = Instruction{Name: "AND", Operate: AND, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2}
-	c.lookup[0x31] = Instruction{Name: "AND", Operate: AND, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2}
+	// Logical instructions - ADD page cross penalty for indexed modes
+	c.lookup[0x29] = Instruction{Name: "AND", Operate: AND, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x25] = Instruction{Name: "AND", Operate: AND, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x35] = Instruction{Name: "AND", Operate: AND, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x2D] = Instruction{Name: "AND", Operate: AND, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x3D] = Instruction{Name: "AND", Operate: AND, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0x39] = Instruction{Name: "AND", Operate: AND, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0x21] = Instruction{Name: "AND", Operate: AND, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x31] = Instruction{Name: "AND", Operate: AND, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2, PageCrossPenalty: true}
 
-	c.lookup[0x49] = Instruction{Name: "EOR", Operate: EOR, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0x45] = Instruction{Name: "EOR", Operate: EOR, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0x55] = Instruction{Name: "EOR", Operate: EOR, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2}
-	c.lookup[0x4D] = Instruction{Name: "EOR", Operate: EOR, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
-	c.lookup[0x5D] = Instruction{Name: "EOR", Operate: EOR, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3}
-	c.lookup[0x59] = Instruction{Name: "EOR", Operate: EOR, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3}
-	c.lookup[0x41] = Instruction{Name: "EOR", Operate: EOR, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2}
-	c.lookup[0x51] = Instruction{Name: "EOR", Operate: EOR, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2}
+	c.lookup[0x49] = Instruction{Name: "EOR", Operate: EOR, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x45] = Instruction{Name: "EOR", Operate: EOR, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x55] = Instruction{Name: "EOR", Operate: EOR, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x4D] = Instruction{Name: "EOR", Operate: EOR, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x5D] = Instruction{Name: "EOR", Operate: EOR, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0x59] = Instruction{Name: "EOR", Operate: EOR, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0x41] = Instruction{Name: "EOR", Operate: EOR, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x51] = Instruction{Name: "EOR", Operate: EOR, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2, PageCrossPenalty: true}
 
-	c.lookup[0x09] = Instruction{Name: "ORA", Operate: ORA, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0x05] = Instruction{Name: "ORA", Operate: ORA, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0x15] = Instruction{Name: "ORA", Operate: ORA, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2}
-	c.lookup[0x0D] = Instruction{Name: "ORA", Operate: ORA, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
-	c.lookup[0x1D] = Instruction{Name: "ORA", Operate: ORA, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3}
-	c.lookup[0x19] = Instruction{Name: "ORA", Operate: ORA, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3}
-	c.lookup[0x01] = Instruction{Name: "ORA", Operate: ORA, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2}
-	c.lookup[0x11] = Instruction{Name: "ORA", Operate: ORA, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2}
+	c.lookup[0x09] = Instruction{Name: "ORA", Operate: ORA, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x05] = Instruction{Name: "ORA", Operate: ORA, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x15] = Instruction{Name: "ORA", Operate: ORA, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x0D] = Instruction{Name: "ORA", Operate: ORA, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x1D] = Instruction{Name: "ORA", Operate: ORA, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0x19] = Instruction{Name: "ORA", Operate: ORA, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0x01] = Instruction{Name: "ORA", Operate: ORA, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x11] = Instruction{Name: "ORA", Operate: ORA, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2, PageCrossPenalty: true}
 
-	c.lookup[0x24] = Instruction{Name: "BIT", Operate: BIT, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0x2C] = Instruction{Name: "BIT", Operate: BIT, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
+	// BIT instruction - no page cross possible
+	c.lookup[0x24] = Instruction{Name: "BIT", Operate: BIT, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x2C] = Instruction{Name: "BIT", Operate: BIT, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
 
-	c.lookup[0xC9] = Instruction{Name: "CMP", Operate: CMP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0xC5] = Instruction{Name: "CMP", Operate: CMP, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0xD5] = Instruction{Name: "CMP", Operate: CMP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2}
-	c.lookup[0xCD] = Instruction{Name: "CMP", Operate: CMP, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
-	c.lookup[0xDD] = Instruction{Name: "CMP", Operate: CMP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3}
-	c.lookup[0xD9] = Instruction{Name: "CMP", Operate: CMP, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3}
-	c.lookup[0xC1] = Instruction{Name: "CMP", Operate: CMP, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2}
-	c.lookup[0xD1] = Instruction{Name: "CMP", Operate: CMP, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2}
+	// Compare instructions - ADD page cross penalty for indexed modes
+	c.lookup[0xC9] = Instruction{Name: "CMP", Operate: CMP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xC5] = Instruction{Name: "CMP", Operate: CMP, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xD5] = Instruction{Name: "CMP", Operate: CMP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xCD] = Instruction{Name: "CMP", Operate: CMP, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
+	c.lookup[0xDD] = Instruction{Name: "CMP", Operate: CMP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0xD9] = Instruction{Name: "CMP", Operate: CMP, AddrMode: ABY, AddrModeType: AddrModeABY, Cycles: 4, Length: 3, PageCrossPenalty: true}
+	c.lookup[0xC1] = Instruction{Name: "CMP", Operate: CMP, AddrMode: IZX, AddrModeType: AddrModeIZX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xD1] = Instruction{Name: "CMP", Operate: CMP, AddrMode: IZY, AddrModeType: AddrModeIZY, Cycles: 5, Length: 2, PageCrossPenalty: true}
 
-	c.lookup[0xE0] = Instruction{Name: "CPX", Operate: CPX, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0xE4] = Instruction{Name: "CPX", Operate: CPX, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0xEC] = Instruction{Name: "CPX", Operate: CPX, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
+	// CPX, CPY - no indexed modes that can cross pages
+	c.lookup[0xE0] = Instruction{Name: "CPX", Operate: CPX, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xE4] = Instruction{Name: "CPX", Operate: CPX, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xEC] = Instruction{Name: "CPX", Operate: CPX, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
 
-	c.lookup[0xC0] = Instruction{Name: "CPY", Operate: CPY, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2}
-	c.lookup[0xC4] = Instruction{Name: "CPY", Operate: CPY, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2}
-	c.lookup[0xCC] = Instruction{Name: "CPY", Operate: CPY, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3}
+	c.lookup[0xC0] = Instruction{Name: "CPY", Operate: CPY, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xC4] = Instruction{Name: "CPY", Operate: CPY, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xCC] = Instruction{Name: "CPY", Operate: CPY, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, PageCrossPenalty: false}
 
-	c.lookup[0x90] = Instruction{Name: "BCC", Operate: BCC, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2}
-	c.lookup[0xB0] = Instruction{Name: "BCS", Operate: BCS, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2}
-	c.lookup[0xF0] = Instruction{Name: "BEQ", Operate: BEQ, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2}
-	c.lookup[0x30] = Instruction{Name: "BMI", Operate: BMI, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2}
-	c.lookup[0xD0] = Instruction{Name: "BNE", Operate: BNE, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2}
-	c.lookup[0x10] = Instruction{Name: "BPL", Operate: BPL, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2}
-	c.lookup[0x50] = Instruction{Name: "BVC", Operate: BVC, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2}
-	c.lookup[0x70] = Instruction{Name: "BVS", Operate: BVS, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2}
+	// Branch instructions - no page cross penalty (handled by branch logic)
+	c.lookup[0x90] = Instruction{Name: "BCC", Operate: BCC, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xB0] = Instruction{Name: "BCS", Operate: BCS, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xF0] = Instruction{Name: "BEQ", Operate: BEQ, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x30] = Instruction{Name: "BMI", Operate: BMI, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0xD0] = Instruction{Name: "BNE", Operate: BNE, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x10] = Instruction{Name: "BPL", Operate: BPL, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x50] = Instruction{Name: "BVC", Operate: BVC, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x70] = Instruction{Name: "BVS", Operate: BVS, AddrMode: REL, AddrModeType: AddrModeREL, Cycles: 2, Length: 2, PageCrossPenalty: false}
 
-	c.lookup[0x4C] = Instruction{Name: "JMP", Operate: JMP, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 3, Length: 3}
-	c.lookup[0x6C] = Instruction{Name: "JMP", Operate: JMP, AddrMode: IND, AddrModeType: AddrModeIND, Cycles: 5, Length: 3}
-	c.lookup[0x20] = Instruction{Name: "JSR", Operate: JSR, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3}
-	c.lookup[0x60] = Instruction{Name: "RTS", Operate: RTS, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 6, Length: 1}
+	// Jump and control flow instructions - no page cross penalty
+	c.lookup[0x4C] = Instruction{Name: "JMP", Operate: JMP, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 3, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x6C] = Instruction{Name: "JMP", Operate: JMP, AddrMode: IND, AddrModeType: AddrModeIND, Cycles: 5, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x20] = Instruction{Name: "JSR", Operate: JSR, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x60] = Instruction{Name: "RTS", Operate: RTS, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 6, Length: 1, PageCrossPenalty: false}
 
-	c.lookup[0x00] = Instruction{Name: "BRK", Operate: BRK, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 7, Length: 1}
-	c.lookup[0x40] = Instruction{Name: "RTI", Operate: RTI, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 6, Length: 1}
+	c.lookup[0x00] = Instruction{Name: "BRK", Operate: BRK, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 7, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x40] = Instruction{Name: "RTI", Operate: RTI, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 6, Length: 1, PageCrossPenalty: false}
 
-	c.lookup[0x18] = Instruction{Name: "CLC", Operate: CLC, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0xD8] = Instruction{Name: "CLD", Operate: CLD, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x58] = Instruction{Name: "CLI", Operate: CLI, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0xB8] = Instruction{Name: "CLV", Operate: CLV, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x38] = Instruction{Name: "SEC", Operate: SEC, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0xF8] = Instruction{Name: "SED", Operate: SED, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
-	c.lookup[0x78] = Instruction{Name: "SEI", Operate: SEI, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
+	// Flag instructions - no page cross penalty
+	c.lookup[0x18] = Instruction{Name: "CLC", Operate: CLC, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0xD8] = Instruction{Name: "CLD", Operate: CLD, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x58] = Instruction{Name: "CLI", Operate: CLI, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0xB8] = Instruction{Name: "CLV", Operate: CLV, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x38] = Instruction{Name: "SEC", Operate: SEC, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0xF8] = Instruction{Name: "SED", Operate: SED, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x78] = Instruction{Name: "SEI", Operate: SEI, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
 
-	c.lookup[0xEA] = Instruction{Name: "NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1}
+	c.lookup[0xEA] = Instruction{Name: "NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
 
 	// Illegal NOPs
 	// https://www.masswerk.at/6502/6502_instruction_set.html#NOPs
-	c.lookup[0x1A] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true}
-	c.lookup[0x3A] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true}
-	c.lookup[0x5A] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true}
-	c.lookup[0x7A] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true}
-	c.lookup[0xDA] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true}
-	c.lookup[0xFA] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true}
+	c.lookup[0x1A] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0x3A] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0x5A] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0x7A] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0xDA] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0xFA] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, Illegal: true, PageCrossPenalty: false}
 
-	c.lookup[0x80] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, Illegal: true}
-	c.lookup[0x82] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, Illegal: true}
-	c.lookup[0x89] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, Illegal: true}
-	c.lookup[0xC2] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, Illegal: true}
-	c.lookup[0xE2] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, Illegal: true}
+	c.lookup[0x80] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0x82] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0x89] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0xC2] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0xE2] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, Illegal: true, PageCrossPenalty: false}
 
-	c.lookup[0x04] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, Illegal: true}
-	c.lookup[0x44] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, Illegal: true}
-	c.lookup[0x64] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, Illegal: true}
+	c.lookup[0x04] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0x44] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0x64] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 3, Length: 2, Illegal: true, PageCrossPenalty: false}
 
-	c.lookup[0x14] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true}
-	c.lookup[0x34] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true}
-	c.lookup[0x54] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true}
-	c.lookup[0x74] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true}
-	c.lookup[0xD4] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true}
-	c.lookup[0xF4] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true}
+	c.lookup[0x14] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0x34] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0x54] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0x74] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0xD4] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true, PageCrossPenalty: false}
+	c.lookup[0xF4] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 4, Length: 2, Illegal: true, PageCrossPenalty: false}
 
-	c.lookup[0x0C] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, Illegal: true}
+	c.lookup[0x0C] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 4, Length: 3, Illegal: true, PageCrossPenalty: false}
 
-	c.lookup[0x1C] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true} // +1 cycle if page crossed
-	c.lookup[0x3C] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true} // +1 cycle if page crossed
-	c.lookup[0x5C] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true} // +1 cycle if page crossed
-	c.lookup[0x7C] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true} // +1 cycle if page crossed
-	c.lookup[0xDC] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true} // +1 cycle if page crossed
-	c.lookup[0xFC] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true} // +1 cycle if page crossed
+	// Unofficial NOPs with ABX addressing - ADD page cross penalty
+	c.lookup[0x1C] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true, PageCrossPenalty: true}
+	c.lookup[0x3C] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true, PageCrossPenalty: true}
+	c.lookup[0x5C] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true, PageCrossPenalty: true}
+	c.lookup[0x7C] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true, PageCrossPenalty: true}
+	c.lookup[0xDC] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true, PageCrossPenalty: true}
+	c.lookup[0xFC] = Instruction{Name: "*NOP", Operate: NOP, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 4, Length: 3, Illegal: true, PageCrossPenalty: true}
 
 }
 
@@ -1496,7 +1520,13 @@ func (c *CPU) Clock() error {
 		addrModeCycles := c.currentInstruction.AddrMode(c)
 		opCycles := c.currentInstruction.Operate(c)
 
-		c.cycles = baseCycles + addrModeCycles + opCycles
+		// Only add addressing mode cycles if instruction supports page cross penalty
+		if c.currentInstruction.PageCrossPenalty {
+			c.cycles = baseCycles + addrModeCycles + opCycles
+		} else {
+			// Ignore addressing mode cycles (page cross doesn't add cycle)
+			c.cycles = baseCycles + opCycles
+		}
 
 		// Ensure U is set after execution as well (might be cleared by PLP?)
 		c.setFlag(U, true)

--- a/cpu_page_cross_test.go
+++ b/cpu_page_cross_test.go
@@ -1,0 +1,289 @@
+package cpu6502
+
+import (
+	"testing"
+)
+
+// TestPageCrossPenalty tests that instructions correctly add or don't add
+// the +1 cycle penalty when crossing page boundaries
+func TestPageCrossPenalty(t *testing.T) {
+	tests := []struct {
+		name          string
+		opcode        uint8
+		baseAddr      uint16
+		indexReg      string // "X" or "Y"
+		indexValue    uint8
+		expectCross   bool
+		baseCycles    uint8
+		expectedTotal uint8
+	}{
+		// LDA tests - should add penalty
+		{
+			name:   "LDA ABX Page Cross",
+			opcode: 0xBD, baseAddr: 0x20FF, indexReg: "X", indexValue: 0x02,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+		{
+			name:   "LDA ABX No Cross",
+			opcode: 0xBD, baseAddr: 0x2000, indexReg: "X", indexValue: 0x10,
+			expectCross: false, baseCycles: 4, expectedTotal: 4,
+		},
+		{
+			name:   "LDA ABY Page Cross",
+			opcode: 0xB9, baseAddr: 0x30FF, indexReg: "Y", indexValue: 0x01,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+		{
+			name:   "LDA ABY No Cross",
+			opcode: 0xB9, baseAddr: 0x3000, indexReg: "Y", indexValue: 0x50,
+			expectCross: false, baseCycles: 4, expectedTotal: 4,
+		},
+
+		// STA tests - should NOT add penalty (always full cycles)
+		{
+			name:   "STA ABX Page Cross No Penalty",
+			opcode: 0x9D, baseAddr: 0x20FF, indexReg: "X", indexValue: 0x02,
+			expectCross: true, baseCycles: 5, expectedTotal: 5,
+		},
+		{
+			name:   "STA ABY Page Cross No Penalty",
+			opcode: 0x99, baseAddr: 0x20FF, indexReg: "Y", indexValue: 0x02,
+			expectCross: true, baseCycles: 5, expectedTotal: 5,
+		},
+
+		// ADC tests - should add penalty
+		{
+			name:   "ADC ABX Page Cross",
+			opcode: 0x7D, baseAddr: 0x40FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+		{
+			name:   "ADC ABY No Cross",
+			opcode: 0x79, baseAddr: 0x4000, indexReg: "Y", indexValue: 0x20,
+			expectCross: false, baseCycles: 4, expectedTotal: 4,
+		},
+
+		// SBC tests - should add penalty
+		{
+			name:   "SBC ABX Page Cross",
+			opcode: 0xFD, baseAddr: 0x50FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+
+		// AND tests - should add penalty
+		{
+			name:   "AND ABX Page Cross",
+			opcode: 0x3D, baseAddr: 0x60FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+		{
+			name:   "AND ABY No Cross",
+			opcode: 0x39, baseAddr: 0x6000, indexReg: "Y", indexValue: 0x10,
+			expectCross: false, baseCycles: 4, expectedTotal: 4,
+		},
+
+		// EOR tests - should add penalty
+		{
+			name:   "EOR ABX Page Cross",
+			opcode: 0x5D, baseAddr: 0x70FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+
+		// ORA tests - should add penalty
+		{
+			name:   "ORA ABY Page Cross",
+			opcode: 0x19, baseAddr: 0x80FF, indexReg: "Y", indexValue: 0x01,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+
+		// CMP tests - should add penalty
+		{
+			name:   "CMP ABX Page Cross",
+			opcode: 0xDD, baseAddr: 0x90FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+		{
+			name:   "CMP ABY No Cross",
+			opcode: 0xD9, baseAddr: 0x9000, indexReg: "Y", indexValue: 0x30,
+			expectCross: false, baseCycles: 4, expectedTotal: 4,
+		},
+
+		// LDX tests - should add penalty
+		{
+			name:   "LDX ABY Page Cross",
+			opcode: 0xBE, baseAddr: 0xA0FF, indexReg: "Y", indexValue: 0x01,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+
+		// LDY tests - should add penalty
+		{
+			name:   "LDY ABX Page Cross",
+			opcode: 0xBC, baseAddr: 0xB0FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+
+		// Read-Modify-Write tests - should NOT add penalty
+		{
+			name:   "ASL ABX Page Cross No Penalty",
+			opcode: 0x1E, baseAddr: 0xC0FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 7, expectedTotal: 7,
+		},
+		{
+			name:   "LSR ABX Page Cross No Penalty",
+			opcode: 0x5E, baseAddr: 0xD0FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 7, expectedTotal: 7,
+		},
+		{
+			name:   "ROL ABX Page Cross No Penalty",
+			opcode: 0x3E, baseAddr: 0xE0FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 7, expectedTotal: 7,
+		},
+		{
+			name:   "ROR ABX Page Cross No Penalty",
+			opcode: 0x7E, baseAddr: 0xF0FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 7, expectedTotal: 7,
+		},
+		{
+			name:   "INC ABX Page Cross No Penalty",
+			opcode: 0xFE, baseAddr: 0x10FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 7, expectedTotal: 7,
+		},
+		{
+			name:   "DEC ABX Page Cross No Penalty",
+			opcode: 0xDE, baseAddr: 0x11FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 7, expectedTotal: 7,
+		},
+
+		// Unofficial NOP tests - should add penalty for ABX
+		{
+			name:   "NOP ABX Page Cross (0x1C)",
+			opcode: 0x1C, baseAddr: 0x12FF, indexReg: "X", indexValue: 0x01,
+			expectCross: true, baseCycles: 4, expectedTotal: 5,
+		},
+		{
+			name:   "NOP ABX No Cross (0x3C)",
+			opcode: 0x3C, baseAddr: 0x1300, indexReg: "X", indexValue: 0x10,
+			expectCross: false, baseCycles: 4, expectedTotal: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a simple RAM bus
+			bus := NewMockBus()
+			cpu := NewCPU(bus)
+
+			// Set index register
+			if tt.indexReg == "X" {
+				cpu.X = tt.indexValue
+			} else {
+				cpu.Y = tt.indexValue
+			}
+
+			// Write instruction at PC
+			cpu.PC = 0x8000
+			bus.Write(0x8000, tt.opcode)
+			bus.Write(0x8001, uint8(tt.baseAddr&0xFF))
+			bus.Write(0x8002, uint8(tt.baseAddr>>8))
+
+			// Write some data at the target address for read instructions
+			effectiveAddr := tt.baseAddr + uint16(tt.indexValue)
+			bus.Write(effectiveAddr, 0x42)
+
+			// Execute instruction
+			startCycles := cpu.TotalCycles()
+			for cpu.RemainingCycles() > 0 || cpu.TotalCycles() == startCycles {
+				if err := cpu.Clock(); err != nil {
+					t.Fatalf("Clock error: %v", err)
+				}
+			}
+			cyclesUsed := uint8(cpu.TotalCycles() - startCycles)
+
+			// Verify cycle count
+			if cyclesUsed != tt.expectedTotal {
+				t.Errorf("Expected %d cycles, got %d cycles", tt.expectedTotal, cyclesUsed)
+			}
+
+			// Verify page cross detection
+			actualCross := (effectiveAddr & 0xFF00) != (tt.baseAddr & 0xFF00)
+			if actualCross != tt.expectCross {
+				t.Errorf("Page cross detection mismatch: expected %v, got %v", tt.expectCross, actualCross)
+			}
+		})
+	}
+}
+
+// TestPageCrossPenaltyIZY tests indirect indexed (IZY) mode page crossing
+func TestPageCrossPenaltyIZY(t *testing.T) {
+	tests := []struct {
+		name          string
+		opcode        uint8
+		zpAddr        uint8
+		baseAddr      uint16
+		yValue        uint8
+		expectCross   bool
+		baseCycles    uint8
+		expectedTotal uint8
+	}{
+		{
+			name:   "LDA IZY Page Cross",
+			opcode: 0xB1, zpAddr: 0x10, baseAddr: 0x20FF, yValue: 0x02,
+			expectCross: true, baseCycles: 5, expectedTotal: 6,
+		},
+		{
+			name:   "LDA IZY No Cross",
+			opcode: 0xB1, zpAddr: 0x20, baseAddr: 0x2000, yValue: 0x10,
+			expectCross: false, baseCycles: 5, expectedTotal: 5,
+		},
+		{
+			name:   "STA IZY Page Cross No Penalty",
+			opcode: 0x91, zpAddr: 0x30, baseAddr: 0x30FF, yValue: 0x01,
+			expectCross: true, baseCycles: 6, expectedTotal: 6,
+		},
+		{
+			name:   "ADC IZY Page Cross",
+			opcode: 0x71, zpAddr: 0x40, baseAddr: 0x40FF, yValue: 0x01,
+			expectCross: true, baseCycles: 5, expectedTotal: 6,
+		},
+		{
+			name:   "CMP IZY Page Cross",
+			opcode: 0xD1, zpAddr: 0x50, baseAddr: 0x50FF, yValue: 0x01,
+			expectCross: true, baseCycles: 5, expectedTotal: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bus := NewMockBus()
+			cpu := NewCPU(bus)
+
+			cpu.Y = tt.yValue
+			cpu.PC = 0x8000
+
+			// Write instruction
+			bus.Write(0x8000, tt.opcode)
+			bus.Write(0x8001, tt.zpAddr)
+
+			// Write base address to zero page
+			bus.Write(uint16(tt.zpAddr), uint8(tt.baseAddr&0xFF))
+			bus.Write(uint16(tt.zpAddr)+1, uint8(tt.baseAddr>>8))
+
+			// Write data at effective address
+			effectiveAddr := tt.baseAddr + uint16(tt.yValue)
+			bus.Write(effectiveAddr, 0x42)
+
+			// Execute instruction
+			startCycles := cpu.TotalCycles()
+			for cpu.RemainingCycles() > 0 || cpu.TotalCycles() == startCycles {
+				if err := cpu.Clock(); err != nil {
+					t.Fatalf("Clock error: %v", err)
+				}
+			}
+			cyclesUsed := uint8(cpu.TotalCycles() - startCycles)
+
+			if cyclesUsed != tt.expectedTotal {
+				t.Errorf("Expected %d cycles, got %d cycles", tt.expectedTotal, cyclesUsed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add PageCrossPenalty field to Instruction struct
- Update Clock() to respect page cross penalty flag
- Update all 256 opcodes in buildLookupTable() with correct penalty flags
  - Read instructions (LDA, LDX, LDY, AND, EOR, ORA, ADC, SBC, CMP) add +1 cycle on page cross
  - Write instructions (STA, STX, STY) do NOT add extra cycle
  - Read-modify-write (ASL, LSR, ROL, ROR, INC, DEC) do NOT add extra cycle
  - Unofficial NOPs with ABX addressing add +1 cycle on page cross
- Update operate functions to return 0 (page cross handled by PageCrossPenalty field)
- Simplify NOP function (page cross now handled by lookup table)
- Add comprehensive documentation for page cross behavior
- Add extensive test suite for page cross penalty verification

Implements plan from plandocs/07-medium-priority-page-cross-accuracy.md