### PR TITLE
Expand Test Coverage

### DIFF
--- a/cpu_cycles_test.go
+++ b/cpu_cycles_test.go
@@ -1,0 +1,267 @@
+package cpu6502
+
+import (
+	"testing"
+)
+
+// TestCycleAccuracy verifies exact cycle counts for all instructions
+func TestCycleAccuracy(t *testing.T) {
+	tests := []struct {
+		name           string
+		program        []uint8
+		setup          func(cpu *CPU, bus *MockBus)
+		expectedCycles uint64
+		description    string
+	}{
+		{
+			name:           "LDA ABX No Page Cross",
+			program:        []uint8{0xBD, 0x00, 0x20, 0x00}, // LDA $2000,X
+			setup:          func(cpu *CPU, bus *MockBus) { cpu.X = 0x10 },
+			expectedCycles: 4,
+			description:    "Base cycles, no page cross",
+		},
+		{
+			name:           "LDA ABX Page Cross",
+			program:        []uint8{0xBD, 0xFF, 0x20, 0x00}, // LDA $20FF,X
+			setup:          func(cpu *CPU, bus *MockBus) { cpu.X = 0x02 },
+			expectedCycles: 5,
+			description:    "Base cycles + 1 for page cross",
+		},
+		{
+			name:           "STA ABX Page Cross No Penalty",
+			program:        []uint8{0x9D, 0xFF, 0x20, 0x00}, // STA $20FF,X
+			setup:          func(cpu *CPU, bus *MockBus) { cpu.X = 0x02 },
+			expectedCycles: 5,
+			description:    "Always 5 cycles, page cross doesn't add cycle",
+		},
+		{
+			name:           "Branch Taken No Cross",
+			program:        []uint8{0xD0, 0x10, 0x00}, // BNE +$10
+			setup:          func(cpu *CPU, bus *MockBus) { cpu.setFlag(Z, false) },
+			expectedCycles: 3,
+			description:    "Base 2 + 1 for taken",
+		},
+		{
+			name:           "Branch Taken Page Cross",
+			program:        []uint8{0xD0, 0xFE, 0x00}, // BNE -$02
+			setup:          func(cpu *CPU, bus *MockBus) { cpu.setFlag(Z, false); cpu.PC = 0x8001 },
+			expectedCycles: 4,
+			description:    "Base 2 + 1 for taken + 1 for page cross",
+		},
+		{
+			name:           "Branch Not Taken",
+			program:        []uint8{0xD0, 0x10, 0x00}, // BNE +$10
+			setup:          func(cpu *CPU, bus *MockBus) { cpu.setFlag(Z, true) },
+			expectedCycles: 2,
+			description:    "Base cycles only",
+		},
+		{
+			name:           "ADC Immediate",
+			program:        []uint8{0x69, 0x01, 0x00}, // ADC #$01
+			setup:          func(cpu *CPU, bus *MockBus) { cpu.A = 0x10 },
+			expectedCycles: 2,
+			description:    "Immediate mode, 2 cycles",
+		},
+		{
+			name:           "ADC Zero Page",
+			program:        []uint8{0x65, 0x10, 0x00}, // ADC $10
+			setup:          func(cpu *CPU, bus *MockBus) { cpu.A = 0x10; bus.Write(0x10, 0x05) },
+			expectedCycles: 3,
+			description:    "Zero page, 3 cycles",
+		},
+		{
+			name:           "ADC Absolute",
+			program:        []uint8{0x6D, 0x00, 0x20, 0x00}, // ADC $2000
+			setup:          func(cpu *CPU, bus *MockBus) { cpu.A = 0x10; bus.Write(0x2000, 0x05) },
+			expectedCycles: 4,
+			description:    "Absolute, 4 cycles",
+		},
+		{
+			name:           "INC Zero Page",
+			program:        []uint8{0xE6, 0x10, 0x00}, // INC $10
+			setup:          func(cpu *CPU, bus *MockBus) { bus.Write(0x10, 0x42) },
+			expectedCycles: 5,
+			description:    "Read-modify-write, 5 cycles",
+		},
+		{
+			name:           "INC Absolute",
+			program:        []uint8{0xEE, 0x00, 0x20, 0x00}, // INC $2000
+			setup:          func(cpu *CPU, bus *MockBus) { bus.Write(0x2000, 0x42) },
+			expectedCycles: 6,
+			description:    "Read-modify-write absolute, 6 cycles",
+		},
+		{
+			name:           "JSR",
+			program:        []uint8{0x20, 0x00, 0x90, 0x00}, // JSR $9000
+			setup:          func(cpu *CPU, bus *MockBus) {},
+			expectedCycles: 6,
+			description:    "Jump to subroutine, 6 cycles",
+		},
+		{
+			name:    "RTS",
+			program: []uint8{0x60, 0x00}, // RTS
+			setup: func(cpu *CPU, bus *MockBus) {
+				// Set up stack as if JSR happened
+				cpu.SP = 0xFD - 2
+				bus.Write(stackBase+uint16(cpu.SP+1), 0x00)
+				bus.Write(stackBase+uint16(cpu.SP+2), 0x80)
+			},
+			expectedCycles: 6,
+			description:    "Return from subroutine, 6 cycles",
+		},
+		{
+			name:           "PHA",
+			program:        []uint8{0x48, 0x00}, // PHA
+			setup:          func(cpu *CPU, bus *MockBus) { cpu.A = 0x42 },
+			expectedCycles: 3,
+			description:    "Push accumulator, 3 cycles",
+		},
+		{
+			name:    "PLA",
+			program: []uint8{0x68, 0x00}, // PLA
+			setup: func(cpu *CPU, bus *MockBus) {
+				cpu.SP = 0xFD - 1
+				bus.Write(stackBase+uint16(cpu.SP+1), 0x42)
+			},
+			expectedCycles: 4,
+			description:    "Pull accumulator, 4 cycles",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpu, bus := setupCPU()
+
+			if tt.setup != nil {
+				tt.setup(cpu, bus)
+			}
+
+			startPC := cpu.PC
+			if startPC == 0 {
+				startPC = 0x8000
+				cpu.PC = startPC
+			}
+
+			bus.load(startPC, tt.program)
+			cpu.SetCycles(0)
+
+			startCycles := cpu.TotalCycles()
+			runCycles(cpu, uint(tt.expectedCycles))
+			actualCycles := cpu.TotalCycles() - startCycles
+
+			if actualCycles != tt.expectedCycles {
+				t.Errorf("%s: Expected %d cycles, got %d (%s)",
+					tt.name, tt.expectedCycles, actualCycles, tt.description)
+			}
+		})
+	}
+}
+
+// TestPageCrossCycles specifically tests page boundary crossing behavior
+func TestPageCrossCycles(t *testing.T) {
+	tests := []struct {
+		name          string
+		opcode        uint8
+		baseAddr      uint16
+		indexValue    uint8
+		expectPenalty bool
+		baseCycles    uint64
+		description   string
+	}{
+		// Load instructions - should add cycle on page cross
+		{
+			name:          "LDA ABX No Cross",
+			opcode:        0xBD,
+			baseAddr:      0x2000,
+			indexValue:    0x10,
+			expectPenalty: false,
+			baseCycles:    4,
+			description:   "LDA $2000,X with X=$10 -> $2010 (no cross)",
+		},
+		{
+			name:          "LDA ABX Cross",
+			opcode:        0xBD,
+			baseAddr:      0x20FF,
+			indexValue:    0x02,
+			expectPenalty: true,
+			baseCycles:    4,
+			description:   "LDA $20FF,X with X=$02 -> $2101 (cross)",
+		},
+		{
+			name:          "LDA ABY No Cross",
+			opcode:        0xB9,
+			baseAddr:      0x3000,
+			indexValue:    0x20,
+			expectPenalty: false,
+			baseCycles:    4,
+			description:   "LDA $3000,Y with Y=$20 -> $3020 (no cross)",
+		},
+		{
+			name:          "LDA ABY Cross",
+			opcode:        0xB9,
+			baseAddr:      0x30F0,
+			indexValue:    0x20,
+			expectPenalty: true,
+			baseCycles:    4,
+			description:   "LDA $30F0,Y with Y=$20 -> $3110 (cross)",
+		},
+		// Store instructions - should NOT add cycle on page cross
+		{
+			name:          "STA ABX No Cross",
+			opcode:        0x9D,
+			baseAddr:      0x2000,
+			indexValue:    0x10,
+			expectPenalty: false,
+			baseCycles:    5,
+			description:   "STA $2000,X with X=$10 -> $2010 (no penalty)",
+		},
+		{
+			name:          "STA ABX Cross",
+			opcode:        0x9D,
+			baseAddr:      0x20FF,
+			indexValue:    0x02,
+			expectPenalty: false,
+			baseCycles:    5,
+			description:   "STA $20FF,X with X=$02 -> $2101 (no penalty)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpu, bus := setupCPU()
+
+			// Set up index register
+			if tt.opcode == 0xBD || tt.opcode == 0x9D { // ABX modes
+				cpu.X = tt.indexValue
+			} else { // ABY modes
+				cpu.Y = tt.indexValue
+			}
+
+			// Build program
+			program := []uint8{
+				tt.opcode,
+				uint8(tt.baseAddr & 0xFF),
+				uint8(tt.baseAddr >> 8),
+				0x00, // BRK
+			}
+
+			bus.load(0x8000, program)
+			cpu.PC = 0x8000
+			cpu.SetCycles(0)
+
+			expectedCycles := tt.baseCycles
+			if tt.expectPenalty {
+				expectedCycles++
+			}
+
+			startCycles := cpu.TotalCycles()
+			runCycles(cpu, uint(expectedCycles))
+			actualCycles := cpu.TotalCycles() - startCycles
+
+			if actualCycles != expectedCycles {
+				t.Errorf("%s: Expected %d cycles, got %d (%s)",
+					tt.name, expectedCycles, actualCycles, tt.description)
+			}
+		})
+	}
+}

--- a/cpu_decimal_test.go
+++ b/cpu_decimal_test.go
@@ -1,0 +1,82 @@
+package cpu6502
+
+import (
+	"testing"
+)
+
+// TestDecimalModeEdgeCases tests all BCD edge cases for ADC and SBC
+func TestDecimalModeEdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		instr     string // "ADC" or "SBC"
+		opcode    uint8
+		a         uint8
+		operand   uint8
+		carryIn   bool
+		expectedA uint8
+		expectedC bool
+		expectedZ bool
+		expectedN bool // Based on binary intermediate result
+		expectedV bool // Based on binary intermediate result
+	}{
+		// ADC edge cases
+		{"ADC 99+1 C=0", "ADC", 0x69, 0x99, 0x01, false, 0x00, true, true, true, false},
+		{"ADC 99+0 C=1", "ADC", 0x69, 0x99, 0x00, true, 0x00, true, true, true, false},
+		{"ADC 50+50 C=0", "ADC", 0x69, 0x50, 0x50, false, 0x00, true, true, true, true},
+		{"ADC 09+1 C=0", "ADC", 0x69, 0x09, 0x01, false, 0x10, false, false, false, false},
+		{"ADC 09+1 C=1", "ADC", 0x69, 0x09, 0x01, true, 0x11, false, false, false, false},
+		{"ADC 19+1 C=0", "ADC", 0x69, 0x19, 0x01, false, 0x20, false, false, false, false},
+		{"ADC 00+00 C=0", "ADC", 0x69, 0x00, 0x00, false, 0x00, false, true, false, false},
+		{"ADC 00+00 C=1", "ADC", 0x69, 0x00, 0x00, true, 0x01, false, false, false, false},
+		{"ADC 49+49 C=0", "ADC", 0x69, 0x49, 0x49, false, 0x98, false, false, true, true},
+		{"ADC 50+49 C=0", "ADC", 0x69, 0x50, 0x49, false, 0x99, false, false, true, true},
+
+		// SBC edge cases
+		{"SBC 00-1 C=1", "SBC", 0xE9, 0x00, 0x01, true, 0x99, false, false, true, false},
+		{"SBC 00-1 C=0", "SBC", 0xE9, 0x00, 0x01, false, 0x98, false, false, true, false},
+		{"SBC 10-1 C=1", "SBC", 0xE9, 0x10, 0x01, true, 0x09, true, false, false, false},
+		{"SBC 10-1 C=0", "SBC", 0xE9, 0x10, 0x01, false, 0x08, true, false, false, false},
+		{"SBC 00-0 C=1", "SBC", 0xE9, 0x00, 0x00, true, 0x00, true, true, false, false},
+		{"SBC 00-0 C=0", "SBC", 0xE9, 0x00, 0x00, false, 0x99, false, false, true, false},
+		{"SBC 50-50 C=1", "SBC", 0xE9, 0x50, 0x50, true, 0x00, true, true, false, false},
+		{"SBC 32-2 C=1", "SBC", 0xE9, 0x32, 0x02, true, 0x30, true, false, false, false},
+		{"SBC 12-21 C=1", "SBC", 0xE9, 0x12, 0x21, true, 0x91, false, false, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpu, bus := setupCPU()
+
+			// Enable decimal mode
+			cpu.setFlag(D, true)
+			cpu.setFlag(C, tt.carryIn)
+			cpu.A = tt.a
+
+			// Load instruction
+			program := []uint8{tt.opcode, tt.operand, 0x00}
+			bus.load(0x8000, program)
+			cpu.PC = 0x8000
+			cpu.SetCycles(0)
+
+			// Execute
+			runCycles(cpu, 2)
+
+			// Verify result
+			if cpu.A != tt.expectedA {
+				t.Errorf("Expected A=$%02X, got $%02X", tt.expectedA, cpu.A)
+			}
+			if cpu.getFlag(C) != tt.expectedC {
+				t.Errorf("Expected C=%v, got %v", tt.expectedC, cpu.getFlag(C))
+			}
+			if cpu.getFlag(Z) != tt.expectedZ {
+				t.Errorf("Expected Z=%v, got %v", tt.expectedZ, cpu.getFlag(Z))
+			}
+			if cpu.getFlag(N) != tt.expectedN {
+				t.Errorf("Expected N=%v, got %v", tt.expectedN, cpu.getFlag(N))
+			}
+			if cpu.getFlag(V) != tt.expectedV {
+				t.Errorf("Expected V=%v, got %v", tt.expectedV, cpu.getFlag(V))
+			}
+		})
+	}
+}

--- a/cpu_fuzz_test.go
+++ b/cpu_fuzz_test.go
@@ -1,0 +1,129 @@
+package cpu6502
+
+import (
+	"testing"
+)
+
+// FuzzCPUExecution fuzzes CPU execution with random programs
+func FuzzCPUExecution(f *testing.F) {
+	// Add seed corpus - valid 6502 programs
+	f.Add([]byte{0xA9, 0x42, 0x00})             // LDA #$42, BRK
+	f.Add([]byte{0x69, 0x01, 0x00})             // ADC #$01, BRK
+	f.Add([]byte{0xE9, 0x01, 0x00})             // SBC #$01, BRK
+	f.Add([]byte{0xA2, 0x10, 0xE8, 0x00})       // LDX #$10, INX, BRK
+	f.Add([]byte{0xA0, 0x20, 0xC8, 0x00})       // LDY #$20, INY, BRK
+	f.Add([]byte{0x18, 0x69, 0xFF, 0x00})       // CLC, ADC #$FF, BRK
+	f.Add([]byte{0x38, 0xE9, 0x01, 0x00})       // SEC, SBC #$01, BRK
+	f.Add([]byte{0xA9, 0x00, 0x29, 0xFF, 0x00}) // LDA #$00, AND #$FF, BRK
+
+	f.Fuzz(func(t *testing.T, program []byte) {
+		// Skip empty or very large programs
+		if len(program) == 0 || len(program) > 256 {
+			return
+		}
+
+		cpu, bus := setupCPU()
+		bus.load(0x8000, program)
+		cpu.PC = 0x8000
+		cpu.SetCycles(0)
+
+		// Execute with timeout to prevent infinite loops
+		maxCycles := uint64(len(program) * 10)
+		for i := uint64(0); i < maxCycles; i++ {
+			if err := cpu.Clock(); err != nil {
+				// Error is acceptable (illegal opcode, etc.)
+				return
+			}
+
+			// Stop on BRK
+			if cpu.PC < 0x8000 || cpu.PC >= 0x8000+uint16(len(program)) {
+				// PC went outside program bounds
+				return
+			}
+
+			// Check for BRK opcode at current PC
+			if bus.Read(cpu.PC) == 0x00 && cpu.RemainingCycles() == 0 {
+				return
+			}
+		}
+
+		// If we get here, the program ran for maxCycles without hitting BRK
+		// This is acceptable - just means it's a long-running program
+	})
+}
+
+// FuzzDecimalMode fuzzes decimal mode arithmetic
+func FuzzDecimalMode(f *testing.F) {
+	// Seed with valid BCD values
+	f.Add(uint8(0x00), uint8(0x00), false) // 00 + 00
+	f.Add(uint8(0x09), uint8(0x01), false) // 09 + 01
+	f.Add(uint8(0x99), uint8(0x01), false) // 99 + 01
+	f.Add(uint8(0x50), uint8(0x50), false) // 50 + 50
+	f.Add(uint8(0x99), uint8(0x99), true)  // 99 + 99 + carry
+
+	f.Fuzz(func(t *testing.T, a uint8, operand uint8, carryIn bool) {
+		cpu, bus := setupCPU()
+
+		// Enable decimal mode
+		cpu.setFlag(D, true)
+		cpu.setFlag(C, carryIn)
+		cpu.A = a
+
+		// ADC immediate
+		program := []uint8{0x69, operand, 0x00}
+		bus.load(0x8000, program)
+		cpu.PC = 0x8000
+		cpu.SetCycles(0)
+
+		// Execute ADC
+		if err := cpu.Clock(); err != nil {
+			// Error is acceptable
+			return
+		}
+		if err := cpu.Clock(); err != nil {
+			return
+		}
+
+		// Just verify the CPU didn't crash
+		// We don't validate the result because invalid BCD inputs
+		// have undefined behavior
+	})
+}
+
+// FuzzAddressingModes fuzzes different addressing modes
+func FuzzAddressingModes(f *testing.F) {
+	// Seed with various addressing mode combinations
+	f.Add([]byte{0xA9, 0x42})       // LDA immediate
+	f.Add([]byte{0xA5, 0x10})       // LDA zero page
+	f.Add([]byte{0xAD, 0x00, 0x20}) // LDA absolute
+
+	f.Fuzz(func(t *testing.T, program []byte) {
+		if len(program) == 0 || len(program) > 10 {
+			return
+		}
+
+		cpu, bus := setupCPU()
+
+		// Add BRK at the end
+		fullProgram := append([]byte{}, program...)
+		fullProgram = append(fullProgram, 0x00)
+
+		bus.load(0x8000, fullProgram)
+		cpu.PC = 0x8000
+		cpu.SetCycles(0)
+
+		// Execute with cycle limit
+		maxCycles := uint64(20)
+		for i := uint64(0); i < maxCycles; i++ {
+			if err := cpu.Clock(); err != nil {
+				// Error is acceptable
+				return
+			}
+
+			// Stop if we hit BRK or PC goes out of bounds
+			if cpu.PC < 0x8000 || cpu.PC >= 0x8000+uint16(len(fullProgram)) {
+				return
+			}
+		}
+	})
+}

--- a/cpu_length_test.go
+++ b/cpu_length_test.go
@@ -1,0 +1,83 @@
+package cpu6502
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestInstructionLengthValidation verifies PC advances correctly for all opcodes
+func TestInstructionLengthValidation(t *testing.T) {
+	cpu, bus := setupCPU()
+
+	// Instructions that modify PC in ways other than simple advancement
+	pcModifyingOpcodes := map[uint8]bool{
+		0x00: true, // BRK
+		0x20: true, // JSR
+		0x4C: true, // JMP ABS
+		0x6C: true, // JMP IND
+		0x40: true, // RTI
+		0x60: true, // RTS
+		// Branch instructions
+		0x10: true, // BPL
+		0x30: true, // BMI
+		0x50: true, // BVC
+		0x70: true, // BVS
+		0x90: true, // BCC
+		0xB0: true, // BCS
+		0xD0: true, // BNE
+		0xF0: true, // BEQ
+	}
+
+	// Test all 256 opcodes
+	for opcode := 0; opcode <= 255; opcode++ {
+		t.Run(fmt.Sprintf("Opcode_%02X", opcode), func(t *testing.T) {
+			cpu, bus = setupCPU()
+
+			instr := cpu.LookupInstruction(uint8(opcode))
+
+			// Skip if no length defined
+			if instr.Length == 0 {
+				t.Skip("Instruction length not defined")
+			}
+
+			// Skip instructions that modify PC in special ways
+			if pcModifyingOpcodes[uint8(opcode)] {
+				t.Skip("Instruction modifies PC (branch/jump/interrupt)")
+			}
+
+			// Load instruction with dummy operands
+			startPC := uint16(0x8000)
+			bus.Write(startPC, uint8(opcode))
+			for i := uint8(1); i < instr.Length; i++ {
+				bus.Write(startPC+uint16(i), 0x00)
+			}
+			// Write NOPs after the instruction to prevent accidental BRK execution
+			for i := uint16(0); i < 10; i++ {
+				bus.Write(startPC+uint16(instr.Length)+i, 0xEA) // NOP
+			}
+
+			cpu.PC = startPC
+			cpu.SetCycles(0)
+
+			// Execute just one instruction by tracking initial PC
+			initialPC := cpu.PC
+			maxCycles := uint8(instr.Cycles + 5) // Allow for page cross
+
+			// Run cycles until PC changes (instruction completes)
+			cyclesRun := uint8(0)
+			for cyclesRun < maxCycles && cpu.PC == initialPC {
+				if err := cpu.Clock(); err != nil {
+					t.Fatalf("CPU error: %v", err)
+				}
+				cyclesRun++
+			}
+
+			// Verify PC advanced by instruction length
+			expectedPC := startPC + uint16(instr.Length)
+			if cpu.PC != expectedPC {
+				t.Errorf("Opcode $%02X (%s): Expected PC=$%04X, got $%04X (Length=%d)",
+					opcode, instr.Name, expectedPC, cpu.PC, instr.Length)
+			}
+		})
+	}
+}

--- a/cpu_selfmod_test.go
+++ b/cpu_selfmod_test.go
@@ -1,0 +1,154 @@
+package cpu6502
+
+import (
+	"testing"
+)
+
+// TestSelfModifyingCode verifies behavior with self-modifying code
+func TestSelfModifyingCode(t *testing.T) {
+	t.Run("Modify Next Instruction", func(t *testing.T) {
+		cpu, bus := setupCPU()
+
+		// Program that modifies the next instruction
+		program := []uint8{
+			0xA9, 0xEA, // LDA #$EA (NOP opcode)
+			0x8D, 0x06, 0x80, // STA $8006 (modify next instruction)
+			0x00, // This will become NOP
+			0x00, // BRK
+		}
+
+		bus.load(0x8000, program)
+		cpu.PC = 0x8000
+		cpu.SetCycles(0)
+
+		// Invalidate cache before execution
+		cpu.InvalidateInstructionCache()
+
+		// Execute until BRK
+		runUntilBrk(cpu, bus, 50)
+
+		// Verify the instruction was modified
+		if bus.Read(0x8006) != 0xEA {
+			t.Errorf("Instruction not modified: expected $EA, got $%02X", bus.Read(0x8006))
+		}
+	})
+
+	t.Run("Cache Invalidation", func(t *testing.T) {
+		cpu, bus := setupCPU()
+
+		// Execute instruction from location
+		bus.Write(0x8000, 0xA9) // LDA #$42
+		bus.Write(0x8001, 0x42)
+		bus.Write(0x8002, 0x00) // BRK
+
+		cpu.PC = 0x8000
+		cpu.SetCycles(0)
+		runCycles(cpu, 2)
+
+		if cpu.A != 0x42 {
+			t.Errorf("First execution failed: expected A=$42, got A=$%02X", cpu.A)
+		}
+
+		// Modify the instruction
+		bus.Write(0x8001, 0x99) // Change operand
+
+		// Invalidate cache
+		cpu.InvalidateInstructionCache()
+
+		// Execute again
+		cpu.PC = 0x8000
+		cpu.SetCycles(0)
+		runCycles(cpu, 2)
+
+		if cpu.A != 0x99 {
+			t.Errorf("Modified instruction not executed: expected A=$99, got A=$%02X", cpu.A)
+		}
+	})
+
+	t.Run("Cache Stats", func(t *testing.T) {
+		cpu, bus := setupCPU()
+
+		// Simple loop that should benefit from caching
+		program := []uint8{
+			0xA2, 0x00, // LDX #$00      ; $8000
+			0xE8,       // INX           ; $8002 (loop start)
+			0xE0, 0x05, // CPX #$05      ; $8003
+			0xD0, 0xFB, // BNE -5        ; $8005 (branch to $8002)
+			0x00, // BRK           ; $8007
+		}
+
+		bus.load(0x8000, program)
+		cpu.PC = 0x8000
+		cpu.SetCycles(0)
+
+		// Execute the loop
+		runUntilBrk(cpu, bus, 100)
+
+		// Check cache statistics
+		hits, misses, hitRate := cpu.InstructionCacheStats()
+
+		// We should have some cache hits from the loop
+		if hits == 0 {
+			t.Logf("Warning: No cache hits detected (hits=%d, misses=%d, rate=%.2f%%)",
+				hits, misses, hitRate*100)
+		} else {
+			t.Logf("Cache stats: hits=%d, misses=%d, hit rate=%.2f%%",
+				hits, misses, hitRate*100)
+		}
+
+		// Verify X register has the expected value
+		if cpu.X != 0x05 {
+			t.Errorf("Loop execution failed: expected X=$05, got X=$%02X", cpu.X)
+		}
+	})
+
+	t.Run("Disable and Enable Cache", func(t *testing.T) {
+		cpu, bus := setupCPU()
+
+		// Simple program
+		program := []uint8{
+			0xA9, 0x42, // LDA #$42
+			0x00, // BRK
+		}
+
+		bus.load(0x8000, program)
+
+		// Execute with cache enabled
+		cpu.EnableInstructionCache()
+		cpu.PC = 0x8000
+		cpu.SetCycles(0)
+		runCycles(cpu, 2)
+
+		hits1, misses1, _ := cpu.InstructionCacheStats()
+
+		// Disable cache
+		cpu.DisableInstructionCache()
+		cpu.PC = 0x8000
+		cpu.SetCycles(0)
+		runCycles(cpu, 2)
+
+		hits2, misses2, _ := cpu.InstructionCacheStats()
+
+		// Stats should be zero when cache is disabled
+		if hits2 != 0 || misses2 != 0 {
+			t.Errorf("Cache stats should be zero when disabled: hits=%d, misses=%d", hits2, misses2)
+		}
+
+		// Re-enable cache
+		cpu.EnableInstructionCache()
+		cpu.PC = 0x8000
+		cpu.SetCycles(0)
+		runCycles(cpu, 2)
+
+		hits3, misses3, _ := cpu.InstructionCacheStats()
+
+		// Should have stats again
+		if hits3 == 0 && misses3 == 0 {
+			t.Errorf("Cache stats should not be zero after re-enabling")
+		}
+
+		t.Logf("Cache enabled: hits=%d, misses=%d", hits1, misses1)
+		t.Logf("Cache disabled: hits=%d, misses=%d", hits2, misses2)
+		t.Logf("Cache re-enabled: hits=%d, misses=%d", hits3, misses3)
+	})
+}

--- a/cpu_unofficial_test.go
+++ b/cpu_unofficial_test.go
@@ -1,0 +1,121 @@
+package cpu6502
+
+import (
+	"testing"
+)
+
+// TestUnofficialOpcodes tests behavior of illegal/unofficial opcodes
+// Note: This is a framework for future implementation of unofficial opcodes
+func TestUnofficialOpcodes(t *testing.T) {
+	// Test cases for documented unofficial opcodes
+	tests := []struct {
+		name     string
+		opcode   uint8
+		behavior string
+		verify   func(t *testing.T, cpu *CPU, bus *MockBus)
+	}{
+		{
+			name:     "LAX (Load A and X)",
+			opcode:   0xA7, // LAX Zero Page
+			behavior: "Loads value into both A and X",
+			verify: func(t *testing.T, cpu *CPU, bus *MockBus) {
+				t.Skip("LAX not yet implemented")
+			},
+		},
+		{
+			name:     "SAX (Store A AND X)",
+			opcode:   0x87, // SAX Zero Page
+			behavior: "Stores A & X to memory",
+			verify: func(t *testing.T, cpu *CPU, bus *MockBus) {
+				t.Skip("SAX not yet implemented")
+			},
+		},
+		{
+			name:     "DCP (Decrement and Compare)",
+			opcode:   0xC7, // DCP Zero Page
+			behavior: "Decrements memory then compares with A",
+			verify: func(t *testing.T, cpu *CPU, bus *MockBus) {
+				t.Skip("DCP not yet implemented")
+			},
+		},
+		{
+			name:     "ISC (Increment and Subtract with Carry)",
+			opcode:   0xE7, // ISC Zero Page
+			behavior: "Increments memory then performs SBC",
+			verify: func(t *testing.T, cpu *CPU, bus *MockBus) {
+				t.Skip("ISC not yet implemented")
+			},
+		},
+		{
+			name:     "SLO (Shift Left and OR)",
+			opcode:   0x07, // SLO Zero Page
+			behavior: "ASL then ORA with accumulator",
+			verify: func(t *testing.T, cpu *CPU, bus *MockBus) {
+				t.Skip("SLO not yet implemented")
+			},
+		},
+		{
+			name:     "RLA (Rotate Left and AND)",
+			opcode:   0x27, // RLA Zero Page
+			behavior: "ROL then AND with accumulator",
+			verify: func(t *testing.T, cpu *CPU, bus *MockBus) {
+				t.Skip("RLA not yet implemented")
+			},
+		},
+		{
+			name:     "SRE (Shift Right and EOR)",
+			opcode:   0x47, // SRE Zero Page
+			behavior: "LSR then EOR with accumulator",
+			verify: func(t *testing.T, cpu *CPU, bus *MockBus) {
+				t.Skip("SRE not yet implemented")
+			},
+		},
+		{
+			name:     "RRA (Rotate Right and ADC)",
+			opcode:   0x67, // RRA Zero Page
+			behavior: "ROR then ADC with accumulator",
+			verify: func(t *testing.T, cpu *CPU, bus *MockBus) {
+				t.Skip("RRA not yet implemented")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpu, bus := setupCPU()
+			tt.verify(t, cpu, bus)
+		})
+	}
+}
+
+// TestUnofficialNOPs verifies that unofficial NOP variants work correctly
+func TestUnofficialNOPs(t *testing.T) {
+	// These are already tested in TestNopInstructions in cpu_test.go
+	// This test just verifies they are marked as illegal but functional
+
+	unofficialNOPs := []uint8{
+		0x1A, 0x3A, 0x5A, 0x7A, 0xDA, 0xFA, // Implied NOPs
+		0x80, 0x82, 0x89, 0xC2, 0xE2, // Immediate NOPs
+		0x04, 0x44, 0x64, // Zero Page NOPs
+		0x14, 0x34, 0x54, 0x74, 0xD4, 0xF4, // Zero Page,X NOPs
+		0x0C,                               // Absolute NOP
+		0x1C, 0x3C, 0x5C, 0x7C, 0xDC, 0xFC, // Absolute,X NOPs
+	}
+
+	for _, opcode := range unofficialNOPs {
+		t.Run("NOP_"+string(rune(opcode)), func(t *testing.T) {
+			cpu, _ := setupCPU()
+
+			// Verify it's marked as illegal
+			if !cpu.IsIllegalOpcode(opcode) {
+				t.Errorf("Opcode $%02X should be marked as illegal", opcode)
+			}
+
+			// Verify it has the NOP operation
+			instr := cpu.LookupInstruction(opcode)
+			if instr.Name != "*NOP" {
+				t.Errorf("Opcode $%02X should be *NOP, got %s", opcode, instr.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements comprehensive test coverage expansion as outlined in plan document 09, adding 600+ lines of new tests across 6 test files.

### Added Tests

- **Decimal Mode:** 19 BCD edge cases (99+1, 00-1, carry propagation)
- **Instruction Length:** Validates PC advancement for all 256 opcodes
- **Unofficial Opcodes:** Framework for 8 illegal opcodes + 27 NOP variants
- **Self-Modifying Code:** Cache invalidation and instruction modification
- **Cycle Accuracy:** 15 timing tests including page boundary crossing
- **Fuzzing:** Random program execution, decimal mode, and addressing modes