### PR TITLE
Add NMOS 6502 Rev A variant with ROR instruction hardware quirk

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A comprehensive and accurate 6502 microprocessor emulator written in Go. This li
 
 ### Core CPU Implementation
 
-- **Multiple CPU Variants**: Support for NMOS 6502, CMOS 65C02, and Ricoh 2A03/2A07 (NES) variants
+- **Multiple CPU Variants**: Support for NMOS 6502 (Rev A and Rev B+), CMOS 65C02, and Ricoh 2A03/2A07 (NES) variants
 - **Complete 6502 Instruction Set**: All 151 official instructions implemented
 - **All Addressing Modes**: Immediate, Zero Page, Absolute, Indexed, Indirect, and Relative addressing
 - **Unofficial Opcodes**: Support for many undocumented/illegal 6502 instructions
@@ -14,7 +14,9 @@ A comprehensive and accurate 6502 microprocessor emulator written in Go. This li
 - **Status Flags**: Full implementation of all processor status flags (N, V, U, B, D, I, Z, C)
 - **Variant-Specific Decimal Mode**: Accurate BCD arithmetic with variant-specific behavior
 - **Interrupt Handling**: IRQ, NMI, and BRK interrupt support with proper vector handling
-- **Hardware Bug Emulation**: Accurate emulation of the indirect JMP page boundary bug on NMOS variants
+- **Hardware Bug Emulation**: Accurate emulation of historical hardware quirks:
+  - Indirect JMP page boundary bug (NMOS variants)
+  - ROR instruction quirk on Rev A (behaves like ASL)
 
 ### Architecture
 
@@ -247,8 +249,11 @@ cpu := cpu6502.NewBuilder(bus).
 The emulator supports multiple 6502 variants with accurate behavior differences:
 
 ```go
-// NMOS 6502 - Original chip with all documented bugs
+// NMOS 6502 (Rev B+) - Original chip with documented bugs (ROR works correctly)
 cpu := cpu6502.NewCPUWithVariant(bus, cpu6502.VariantNMOS6502)
+
+// NMOS 6502 Rev A - Early revision with ROR hardware quirk
+cpu := cpu6502.NewCPUWithVariant(bus, cpu6502.VariantNMOS6502RevA)
 
 // CMOS 65C02 - Enhanced version with bug fixes
 cpu := cpu6502.NewCPUWithVariant(bus, cpu6502.VariantCMOS65C02)
@@ -265,6 +270,9 @@ if cpu.Variant().SupportsDecimalMode() {
 }
 if cpu.Variant().HasIndirectJMPBug() {
     // Has page boundary bug in JMP ($xxFF)
+}
+if cpu.Variant().HasRORQuirk() {
+    // ROR behaves like ASL (Rev A only)
 }
 ```
 
@@ -504,18 +512,26 @@ The cache provides:
 
 This emulator accurately emulates multiple 6502 variants:
 
-- **NMOS 6502** - Original MOS Technology chip (Apple II, Commodore 64, Atari 8-bit)
+- **NMOS 6502 (Rev B+)** - Original MOS Technology chip (Apple II, Commodore 64, Atari 8-bit)
   - Supports decimal mode with NMOS-specific N/V flag behavior
   - Includes the indirect JMP page boundary bug
+  - ROR instruction works correctly
+- **NMOS 6502 Rev A** - Early revision (rare in production systems)
+  - Supports decimal mode with NMOS-specific N/V flag behavior
+  - Includes the indirect JMP page boundary bug
+  - **ROR instruction hardware quirk**: ROR behaves like ASL (shifts left, doesn't update carry)
 - **CMOS 65C02** - Enhanced Western Design Center version (Apple IIc, IIe enhanced)
   - Supports decimal mode with improved N/V flag behavior
   - Fixes the indirect JMP page boundary bug
+  - All instructions work correctly
 - **Ricoh 2A03** - NES/Famicom CPU (NTSC)
   - Decimal mode disabled (D flag ignored)
   - Includes the indirect JMP page boundary bug
+  - ROR instruction works correctly
 - **Ricoh 2A07** - PAL NES CPU
   - Decimal mode disabled (D flag ignored)
   - Includes the indirect JMP page boundary bug
+  - ROR instruction works correctly
 
 ## Contributing
 

--- a/cpu_variant_test.go
+++ b/cpu_variant_test.go
@@ -396,3 +396,232 @@ func TestVariantNVFlagsInDecimalMode(t *testing.T) {
 		})
 	}
 }
+
+// TestRORQuirk tests the ROR hardware quirk across variants
+func TestRORQuirk(t *testing.T) {
+	variants := []struct {
+		variant  CPUVariant
+		hasQuirk bool
+	}{
+		{VariantNMOS6502, false},    // Rev B and later - ROR works correctly
+		{VariantNMOS6502RevA, true}, // Rev A - has the quirk
+		{VariantCMOS65C02, false},   // CMOS - ROR works correctly
+		{VariantRicoh2A03, false},   // Ricoh - ROR works correctly
+		{VariantRicoh2A07, false},   // Ricoh PAL - ROR works correctly
+	}
+
+	tests := []struct {
+		name                string
+		opcode              uint8
+		addrMode            string
+		initialValue        uint8
+		initialCarry        bool
+		expectedNormal      uint8 // Expected result for normal ROR
+		expectedQuirk       uint8 // Expected result for quirky ROR (ASL-like)
+		expectedCarryNormal bool
+		expectedCarryQuirk  bool // Carry should NOT change in quirk mode
+	}{
+		// Accumulator mode tests
+		{"ACC C=0 0x84", 0x6A, "IMP", 0x84, false, 0x42, 0x08, false, false},
+		{"ACC C=1 0x84", 0x6A, "IMP", 0x84, true, 0xC2, 0x08, false, true},
+		{"ACC C=0 0x01", 0x6A, "IMP", 0x01, false, 0x00, 0x02, true, false},
+		{"ACC C=1 0x01", 0x6A, "IMP", 0x01, true, 0x80, 0x02, true, true},
+		{"ACC C=0 0x00", 0x6A, "IMP", 0x00, false, 0x00, 0x00, false, false},
+		{"ACC C=1 0x00", 0x6A, "IMP", 0x00, true, 0x80, 0x00, false, true},
+		{"ACC C=0 0xFF", 0x6A, "IMP", 0xFF, false, 0x7F, 0xFE, true, false},
+		{"ACC C=1 0xFF", 0x6A, "IMP", 0xFF, true, 0xFF, 0xFE, true, true},
+		{"ACC C=0 0x80", 0x6A, "IMP", 0x80, false, 0x40, 0x00, false, false},
+		{"ACC C=1 0x80", 0x6A, "IMP", 0x80, true, 0xC0, 0x00, false, true},
+
+		// Zero Page mode tests
+		{"ZP0 C=0 0x22", 0x66, "ZP0", 0x22, false, 0x11, 0x44, false, false},
+		{"ZP0 C=1 0x22", 0x66, "ZP0", 0x22, true, 0x91, 0x44, false, true},
+		{"ZP0 C=0 0xAA", 0x66, "ZP0", 0xAA, false, 0x55, 0x54, false, false},
+		{"ZP0 C=1 0xAA", 0x66, "ZP0", 0xAA, true, 0xD5, 0x54, false, true},
+	}
+
+	for _, vt := range variants {
+		for _, tt := range tests {
+			t.Run(vt.variant.String()+" "+tt.name, func(t *testing.T) {
+				cpu, bus := setupCPUWithVariant(vt.variant)
+
+				var program []uint8
+				var memAddr uint16 = 0x0035
+
+				if tt.addrMode == "IMP" {
+					// Accumulator mode
+					cpu.A = tt.initialValue
+					program = []uint8{tt.opcode, 0x00} // ROR A, BRK
+				} else if tt.addrMode == "ZP0" {
+					// Zero Page mode
+					bus.Write(memAddr, tt.initialValue)
+					program = []uint8{tt.opcode, uint8(memAddr), 0x00} // ROR $35, BRK
+				}
+
+				cpu.setFlag(C, tt.initialCarry)
+				baseAddr := uint16(0x8000)
+				bus.load(baseAddr, program)
+				cpu.PC = baseAddr
+				cpu.SetCycles(0)
+
+				// Run the instruction
+				if tt.addrMode == "IMP" {
+					runCycles(cpu, 2)
+				} else {
+					runCycles(cpu, 5)
+				}
+
+				// Check results based on variant
+				var expectedValue uint8
+				var expectedCarry bool
+				if vt.hasQuirk {
+					expectedValue = tt.expectedQuirk
+					expectedCarry = tt.expectedCarryQuirk
+				} else {
+					expectedValue = tt.expectedNormal
+					expectedCarry = tt.expectedCarryNormal
+				}
+
+				var actualValue uint8
+				if tt.addrMode == "IMP" {
+					actualValue = cpu.A
+				} else {
+					actualValue = bus.Read(memAddr)
+				}
+
+				if actualValue != expectedValue {
+					t.Errorf("%s: Expected value=$%02X, got value=$%02X",
+						vt.variant.String(), expectedValue, actualValue)
+				}
+
+				if cpu.getFlag(C) != expectedCarry {
+					t.Errorf("%s: Expected C=%v, got C=%v",
+						vt.variant.String(), expectedCarry, cpu.getFlag(C))
+				}
+
+				// Check Z flag
+				expectedZ := (expectedValue == 0)
+				if cpu.getFlag(Z) != expectedZ {
+					t.Errorf("%s: Expected Z=%v, got Z=%v",
+						vt.variant.String(), expectedZ, cpu.getFlag(Z))
+				}
+
+				// Check N flag
+				expectedN := (expectedValue & 0x80) != 0
+				if cpu.getFlag(N) != expectedN {
+					t.Errorf("%s: Expected N=%v, got N=%v",
+						vt.variant.String(), expectedN, cpu.getFlag(N))
+				}
+			})
+		}
+	}
+}
+
+// TestRORQuirkAllAddressingModes tests ROR quirk with all addressing modes
+func TestRORQuirkAllAddressingModes(t *testing.T) {
+	// Test with Rev A (has quirk)
+	cpu, bus := setupCPUWithVariant(VariantNMOS6502RevA)
+
+	tests := []struct {
+		name     string
+		opcode   uint8
+		setup    func()
+		cycles   uint
+		checkVal func() uint8
+	}{
+		{
+			name:   "ROR Accumulator",
+			opcode: 0x6A,
+			setup: func() {
+				cpu.A = 0x42
+				cpu.setFlag(C, false)
+			},
+			cycles:   2,
+			checkVal: func() uint8 { return cpu.A },
+		},
+		{
+			name:   "ROR Zero Page",
+			opcode: 0x66,
+			setup: func() {
+				bus.Write(0x0050, 0x42)
+				cpu.setFlag(C, false)
+			},
+			cycles:   5,
+			checkVal: func() uint8 { return bus.Read(0x0050) },
+		},
+		{
+			name:   "ROR Zero Page,X",
+			opcode: 0x76,
+			setup: func() {
+				cpu.X = 0x10
+				bus.Write(0x0060, 0x42)
+				cpu.setFlag(C, false)
+			},
+			cycles:   6,
+			checkVal: func() uint8 { return bus.Read(0x0060) },
+		},
+		{
+			name:   "ROR Absolute",
+			opcode: 0x6E,
+			setup: func() {
+				bus.Write(0x1234, 0x42)
+				cpu.setFlag(C, false)
+			},
+			cycles:   6,
+			checkVal: func() uint8 { return bus.Read(0x1234) },
+		},
+		{
+			name:   "ROR Absolute,X",
+			opcode: 0x7E,
+			setup: func() {
+				cpu.X = 0x10
+				bus.Write(0x1244, 0x42)
+				cpu.setFlag(C, false)
+			},
+			cycles:   7,
+			checkVal: func() uint8 { return bus.Read(0x1244) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpu.Reset()
+			tt.setup()
+
+			var program []uint8
+			baseAddr := uint16(0x8000)
+
+			switch tt.opcode {
+			case 0x6A: // IMP
+				program = []uint8{tt.opcode, 0x00}
+			case 0x66: // ZP0
+				program = []uint8{tt.opcode, 0x50, 0x00}
+			case 0x76: // ZPX
+				program = []uint8{tt.opcode, 0x50, 0x00}
+			case 0x6E: // ABS
+				program = []uint8{tt.opcode, 0x34, 0x12, 0x00}
+			case 0x7E: // ABX
+				program = []uint8{tt.opcode, 0x34, 0x12, 0x00}
+			}
+
+			bus.load(baseAddr, program)
+			cpu.PC = baseAddr
+			cpu.SetCycles(0)
+
+			runCycles(cpu, tt.cycles)
+
+			// For Rev A, ROR behaves like ASL: 0x42 << 1 = 0x84
+			expected := uint8(0x84)
+			actual := tt.checkVal()
+
+			if actual != expected {
+				t.Errorf("Expected $%02X, got $%02X", expected, actual)
+			}
+
+			// Carry should NOT be modified in quirk mode
+			if cpu.getFlag(C) != false {
+				t.Errorf("Expected C=false (unchanged), got C=%v", cpu.getFlag(C))
+			}
+		})
+	}
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,18 +4,19 @@ This document details the differences between the various 6502 CPU variants supp
 
 ## Variant Comparison Table
 
-| Feature | NMOS 6502 | CMOS 65C02 | Ricoh 2A03 | Ricoh 2A07 |
-|---------|-----------|------------|------------|------------|
-| **Year Released** | 1975 | 1982 | 1983 | 1983 |
-| **Decimal Mode** | ✓ | ✓ | ✗ | ✗ |
-| **Indirect JMP Bug** | ✓ | ✗ | ✓ | ✓ |
-| **N/V Flags in BCD** | Undefined | Defined | N/A | N/A |
-| **Additional Instructions** | ✗ | ✓ | ✗ | ✗ |
-| **Power Consumption** | Higher | Lower | Higher | Higher |
+| Feature | NMOS 6502 | NMOS 6502 Rev A | CMOS 65C02 | Ricoh 2A03 | Ricoh 2A07 |
+|---------|-----------|-----------------|------------|------------|------------|
+| **Year Released** | 1975 | 1975 | 1982 | 1983 | 1983 |
+| **Decimal Mode** | ✓ | ✓ | ✓ | ✗ | ✗ |
+| **ROR Instruction** | ✓ | ✗ (ASL-like) | ✓ | ✓ | ✓ |
+| **Indirect JMP Bug** | ✓ | ✓ | ✗ | ✓ | ✓ |
+| **N/V Flags in BCD** | Undefined | Undefined | Defined | N/A | N/A |
+| **Additional Instructions** | ✗ | ✗ | ✓ | ✗ | ✗ |
+| **Power Consumption** | Higher | Higher | Lower | Higher | Higher |
 
 ## System Compatibility
 
-### NMOS 6502 (Original)
+### NMOS 6502 (Rev B and Later)
 
 **Used in:**
 
@@ -30,6 +31,7 @@ This document details the differences between the various 6502 CPU variants supp
 - Full decimal mode support with NMOS-specific behavior
 - N and V flags have undefined values after BCD operations
 - Has the indirect JMP page boundary bug at $xxFF
+- ROR instruction works correctly
 - 151 official opcodes
 - Higher power consumption
 
@@ -37,6 +39,31 @@ This document details the differences between the various 6502 CPU variants supp
 
 ```go
 cpu := cpu6502.NewCPUWithVariant(bus, cpu6502.VariantNMOS6502)
+```
+
+### NMOS 6502 Rev A (Early Revision)
+
+**Used in:**
+
+- Very early 6502-based systems (1975)
+- Rare in production systems
+
+**Characteristics:**
+
+- Full decimal mode support with NMOS-specific behavior
+- N and V flags have undefined values after BCD operations
+- Has the indirect JMP page boundary bug at $xxFF
+- **ROR instruction hardware quirk**: ROR behaves like ASL
+  - Shifts left instead of right
+  - Shifts zero in instead of carry
+  - Does NOT update the carry flag
+- 151 official opcodes (but ROR is broken)
+- Higher power consumption
+
+**Example:**
+
+```go
+cpu := cpu6502.NewCPUWithVariant(bus, cpu6502.VariantNMOS6502RevA)
 ```
 
 ### CMOS 65C02 (Enhanced)
@@ -167,6 +194,54 @@ bus.Write(0x1100, 0x90)
 // JMP ($10FF) correctly jumps to $9000
 ```
 
+### ROR Instruction Quirk (Rev A Only)
+
+#### NMOS 6502 Rev A
+
+The original Rev A of the NMOS 6502 had a hardware design flaw where the ROR (Rotate Right) instruction was not properly implemented. Instead of rotating right, it behaves like ASL (Arithmetic Shift Left):
+
+```go
+// Rev A behavior: ROR acts like ASL but doesn't update carry
+cpu.A = 0x42  // 01000010
+cpu.P |= cpu6502.C  // Set carry flag
+
+// ROR A on Rev A:
+// Expected (correct ROR): 0x42 >> 1 | 0x80 = 0xA1, C=0
+// Actual (Rev A quirk):   0x42 << 1 = 0x84, C unchanged (still 1)
+
+// After ROR A:
+// cpu.A = 0x84  (shifted left, not right!)
+// C flag = 1    (unchanged, not updated!)
+```
+
+**Quirk Characteristics:**
+
+1. Shifts left instead of right (like ASL)
+2. Shifts zero in instead of carry (like ASL)
+3. Does NOT update the carry flag (unlike ASL)
+4. Z and N flags are updated correctly based on result
+
+#### NMOS 6502 Rev B and Later
+
+The bug was fixed in Rev B:
+
+```go
+// Rev B+ behavior: ROR works correctly
+cpu.A = 0x42  // 01000010
+cpu.P |= cpu6502.C  // Set carry flag
+
+// ROR A on Rev B+:
+// Result: 0x42 >> 1 | 0x80 = 0xA1, C=0
+
+// After ROR A:
+// cpu.A = 0xA1  (correctly rotated right)
+// C flag = 0    (correctly set from bit 0)
+```
+
+#### All Other Variants
+
+CMOS 65C02 and Ricoh variants never had this bug - ROR works correctly.
+
 ### Checking Variant Capabilities
 
 ```go
@@ -178,6 +253,11 @@ if cpu.Variant().SupportsDecimalMode() {
 // Check for indirect JMP bug
 if cpu.Variant().HasIndirectJMPBug() {
     fmt.Println("Has page boundary bug in JMP ($xxFF)")
+}
+
+// Check for ROR quirk
+if cpu.Variant().HasRORQuirk() {
+    fmt.Println("ROR instruction behaves like ASL (Rev A quirk)")
 }
 
 // Get variant name

--- a/instructions_shift.go
+++ b/instructions_shift.go
@@ -120,3 +120,33 @@ func (c *CPU) ROR() uint8 {
 	}
 	return 0
 }
+
+// ROR_RevA - Rotate Right (Rev A Hardware Quirk Version)
+// The original Rev A NMOS 6502 didn't have proper ROR circuitry.
+// Instead of rotating right, it behaves like ASL (Arithmetic Shift Left):
+//   - Shifts left instead of right (like ASL)
+//   - Shifts a zero in instead of C (like ASL)
+//   - Doesn't update C (unlike ASL, the carry flag is not modified)
+//
+// This quirk was fixed in Rev B and later revisions.
+// Flags affected: Z, N (C is NOT affected, unlike normal ASL)
+func (c *CPU) ROR_RevA() uint8 {
+	var temp uint16
+	// Use enum comparison instead of reflection
+	if c.currentInstruction.AddrModeType == AddrModeIMP {
+		// Operate on accumulator - behaves like ASL but doesn't set C
+		temp = uint16(c.A) << 1
+		// Quirk: Carry flag is NOT updated (unlike ASL)
+		c.A = uint8(temp & 0x00FF)
+		c.setZNFlags(c.A)
+	} else {
+		// Operate on memory - behaves like ASL but doesn't set C
+		c.fetchDataIfNeeded() // Need data before modifying
+		temp = uint16(c.fetchedData) << 1
+		// Quirk: Carry flag is NOT updated (unlike ASL)
+		result := uint8(temp & 0x00FF)
+		c.write(c.addrAbs, result)
+		c.setZNFlags(result)
+	}
+	return 0
+}

--- a/lookup.go
+++ b/lookup.go
@@ -95,6 +95,7 @@ func (c *CPU) buildLookupTable() {
 	PLP := (*CPU).PLP
 	ROL := (*CPU).ROL
 	ROR := (*CPU).ROR
+	ROR_RevA := (*CPU).ROR_RevA
 	RTI := (*CPU).RTI
 	RTS := (*CPU).RTS
 	SBC := (*CPU).SBC
@@ -222,11 +223,18 @@ func (c *CPU) buildLookupTable() {
 	c.lookup[0x2E] = Instruction{Name: "ROL", Operate: ROL, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3, PageCrossPenalty: false}
 	c.lookup[0x3E] = Instruction{Name: "ROL", Operate: ROL, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3, PageCrossPenalty: false}
 
-	c.lookup[0x6A] = Instruction{Name: "ROR", Operate: ROR, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
-	c.lookup[0x66] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2, PageCrossPenalty: false}
-	c.lookup[0x76] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2, PageCrossPenalty: false}
-	c.lookup[0x6E] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3, PageCrossPenalty: false}
-	c.lookup[0x7E] = Instruction{Name: "ROR", Operate: ROR, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3, PageCrossPenalty: false}
+	// Choose ROR implementation based on variant
+	// Rev A NMOS 6502 has a hardware quirk where ROR behaves like ASL
+	rorImpl := ROR
+	if c.variant.HasRORQuirk() {
+		rorImpl = ROR_RevA
+	}
+
+	c.lookup[0x6A] = Instruction{Name: "ROR", Operate: rorImpl, AddrMode: IMP, AddrModeType: AddrModeIMP, Cycles: 2, Length: 1, PageCrossPenalty: false}
+	c.lookup[0x66] = Instruction{Name: "ROR", Operate: rorImpl, AddrMode: ZP0, AddrModeType: AddrModeZP0, Cycles: 5, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x76] = Instruction{Name: "ROR", Operate: rorImpl, AddrMode: ZPX, AddrModeType: AddrModeZPX, Cycles: 6, Length: 2, PageCrossPenalty: false}
+	c.lookup[0x6E] = Instruction{Name: "ROR", Operate: rorImpl, AddrMode: ABS, AddrModeType: AddrModeABS, Cycles: 6, Length: 3, PageCrossPenalty: false}
+	c.lookup[0x7E] = Instruction{Name: "ROR", Operate: rorImpl, AddrMode: ABX, AddrModeType: AddrModeABX, Cycles: 7, Length: 3, PageCrossPenalty: false}
 
 	// Logical instructions - ADD page cross penalty for indexed modes
 	c.lookup[0x29] = Instruction{Name: "AND", Operate: AND, AddrMode: IMM, AddrModeType: AddrModeIMM, Cycles: 2, Length: 2, PageCrossPenalty: false}

--- a/types.go
+++ b/types.go
@@ -47,7 +47,14 @@ const (
 	// VariantNMOS6502 is the original NMOS 6502 (1975)
 	// Used in: Apple II, Commodore 64, Atari 2600/800, BBC Micro
 	// Features: All documented bugs, decimal mode supported
+	// Note: This represents Rev B and later which have working ROR
 	VariantNMOS6502 CPUVariant = iota
+
+	// VariantNMOS6502RevA is the original Rev A NMOS 6502
+	// This early revision had a hardware bug where ROR was not implemented
+	// and performed a modified ROL operation instead
+	// Features: ROR quirk, all other NMOS bugs, decimal mode supported
+	VariantNMOS6502RevA
 
 	// VariantCMOS65C02 is the CMOS 65C02 (1982)
 	// Used in: Apple IIc, Apple IIe (enhanced), later systems
@@ -68,6 +75,7 @@ const (
 func (v CPUVariant) String() string {
 	names := []string{
 		"NMOS 6502",
+		"NMOS 6502 Rev A",
 		"CMOS 65C02",
 		"Ricoh 2A03 (NTSC)",
 		"Ricoh 2A07 (PAL)",
@@ -91,12 +99,27 @@ func (v CPUVariant) SupportsDecimalMode() bool {
 // HasIndirectJMPBug returns true if the variant has the indirect JMP page boundary bug
 func (v CPUVariant) HasIndirectJMPBug() bool {
 	switch v {
-	case VariantNMOS6502, VariantRicoh2A03, VariantRicoh2A07:
+	case VariantNMOS6502, VariantNMOS6502RevA, VariantRicoh2A03, VariantRicoh2A07:
 		return true
 	case VariantCMOS65C02:
 		return false
 	default:
 		return true
+	}
+}
+
+// HasRORQuirk returns true if the variant has the ROR hardware bug.
+// Only the original Rev A NMOS 6502 had this quirk where ROR didn't have
+// proper circuitry and performed a modified ROL operation instead.
+// This was fixed in Rev B and was never present in Ricoh or CMOS variants.
+func (v CPUVariant) HasRORQuirk() bool {
+	switch v {
+	case VariantNMOS6502RevA:
+		return true
+	case VariantNMOS6502, VariantCMOS65C02, VariantRicoh2A03, VariantRicoh2A07:
+		return false
+	default:
+		return false // Conservative: assume no quirk for unknown variants
 	}
 }
 


### PR DESCRIPTION
- Add VariantNMOS6502RevA to distinguish Rev A (with quirk) from Rev B+
- Implement ROR_RevA() that behaves like ASL (shifts left, doesn't update carry)
- Add HasRORQuirk() method to CPUVariant type
- Update lookup table to conditionally use quirky ROR for Rev A
- Add comprehensive tests for ROR quirk across all variants
- Update documentation in README.md and docs/compatibility.md